### PR TITLE
Fix bug when passing execute function in creation of new Query

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -19,7 +19,9 @@ export class QueryBuilder<GenericResult, GenericResultOne> {
 
   createTable(params: { tableName: string; schema: string; ifNotExists?: boolean }): Query {
     return new Query(
-      this.execute,
+      (q: Query) => {
+        return this.execute(q)
+      },
       `CREATE TABLE ${params.ifNotExists ? 'IF NOT EXISTS' : ''} ${params.tableName}
               (
                 ${params.schema}
@@ -28,12 +30,16 @@ export class QueryBuilder<GenericResult, GenericResultOne> {
   }
 
   dropTable(params: { tableName: string; ifExists?: boolean }): Query {
-    return new Query(this.execute, `DROP TABLE ${params.ifExists ? 'IF EXISTS' : ''} ${params.tableName}`)
+    return new Query((q: Query) => {
+      return this.execute(q)
+    }, `DROP TABLE ${params.ifExists ? 'IF EXISTS' : ''} ${params.tableName}`)
   }
 
   fetchOne(params: SelectOne): Query {
     return new Query(
-      this.execute,
+      (q: Query) => {
+        return this.execute(q)
+      },
       this._select({ ...params, limit: 1 }),
       params.where ? params.where.params : undefined,
       FetchTypes.ONE
@@ -41,7 +47,14 @@ export class QueryBuilder<GenericResult, GenericResultOne> {
   }
 
   fetchAll(params: SelectAll): Query {
-    return new Query(this.execute, this._select(params), params.where ? params.where.params : undefined, FetchTypes.ALL)
+    return new Query(
+      (q: Query) => {
+        return this.execute(q)
+      },
+      this._select(params),
+      params.where ? params.where.params : undefined,
+      FetchTypes.ALL
+    )
   }
 
   insert(params: Insert): Query {
@@ -57,7 +70,14 @@ export class QueryBuilder<GenericResult, GenericResultOne> {
 
     const fetchType = Array.isArray(params.data) ? FetchTypes.ALL : FetchTypes.ONE
 
-    return new Query(this.execute, this._insert(params), args, fetchType)
+    return new Query(
+      (q: Query) => {
+        return this.execute(q)
+      },
+      this._insert(params),
+      args,
+      fetchType
+    )
   }
 
   update(params: Update): Query {
@@ -67,11 +87,25 @@ export class QueryBuilder<GenericResult, GenericResultOne> {
       args = params.where.params.concat(args)
     }
 
-    return new Query(this.execute, this._update(params), args, FetchTypes.ALL)
+    return new Query(
+      (q: Query) => {
+        return this.execute(q)
+      },
+      this._update(params),
+      args,
+      FetchTypes.ALL
+    )
   }
 
   delete(params: Delete): Query {
-    return new Query(this.execute, this._delete(params), params.where ? params.where.params : undefined, FetchTypes.ALL)
+    return new Query(
+      (q: Query) => {
+        return this.execute(q)
+      },
+      this._delete(params),
+      params.where ? params.where.params : undefined,
+      FetchTypes.ALL
+    )
   }
 
   _parse_arguments(row: Record<string, string | boolean | number | null | Raw>): Array<any> {

--- a/test/Builder.test.ts
+++ b/test/Builder.test.ts
@@ -124,7 +124,8 @@ describe('QueryBuilder', () => {
 
     expect(execute).toHaveBeenCalledWith(
       expect.objectContaining({
-        query: 'INSERT OR REPLACE INTO testTable (my_field, another) VALUES (?1, ?2), (?3, ?4), (?5, ?6) RETURNING id, my_field',
+        query:
+          'INSERT OR REPLACE INTO testTable (my_field, another) VALUES (?1, ?2), (?3, ?4), (?5, ?6) RETURNING id, my_field',
         arguments: ['test1', 123, 'test2', 456, 'test3', 789],
         fetchType: FetchTypes.ALL,
       })
@@ -153,7 +154,7 @@ describe('QueryBuilder', () => {
       expect.objectContaining({
         query: 'UPDATE testTable SET my_field = ?2 WHERE field = ?1',
         arguments: ['test_where', 'test_data'],
-        fetchType: FetchTypes.ALL
+        fetchType: FetchTypes.ALL,
       })
     )
   })
@@ -179,7 +180,7 @@ describe('QueryBuilder', () => {
       expect.objectContaining({
         query: 'UPDATE testTable SET my_field = ?2, updated_at = CURRENT_TIMESTAMP, another = ?3 WHERE field = ?1',
         arguments: ['test_where', 'test_data', '123'],
-        fetchType: FetchTypes.ALL
+        fetchType: FetchTypes.ALL,
       })
     )
   })

--- a/test/Builder.test.ts
+++ b/test/Builder.test.ts
@@ -123,12 +123,11 @@ describe('QueryBuilder', () => {
       .execute()
 
     expect(execute).toHaveBeenCalledWith(
-      new Query(
-        qb.execute,
-        'INSERT OR REPLACE INTO testTable (my_field, another) VALUES (?1, ?2), (?3, ?4), (?5, ?6) RETURNING id, my_field',
-        ['test1', 123, 'test2', 456, 'test3', 789],
-        FetchTypes.ALL
-      )
+      expect.objectContaining({
+        query: 'INSERT OR REPLACE INTO testTable (my_field, another) VALUES (?1, ?2), (?3, ?4), (?5, ?6) RETURNING id, my_field',
+        arguments: ['test1', 123, 'test2', 456, 'test3', 789],
+        fetchType: FetchTypes.ALL,
+      })
     )
   })
 
@@ -151,12 +150,11 @@ describe('QueryBuilder', () => {
     }).execute()
 
     expect(execute).toHaveBeenCalledWith(
-      new Query(
-        qb.execute,
-        'UPDATE testTable SET my_field = ?2 WHERE field = ?1',
-        ['test_where', 'test_data'],
-        FetchTypes.ALL
-      )
+      expect.objectContaining({
+        query: 'UPDATE testTable SET my_field = ?2 WHERE field = ?1',
+        arguments: ['test_where', 'test_data'],
+        fetchType: FetchTypes.ALL
+      })
     )
   })
 
@@ -178,12 +176,11 @@ describe('QueryBuilder', () => {
     }).execute()
 
     expect(execute).toHaveBeenCalledWith(
-      new Query(
-        qb.execute,
-        'UPDATE testTable SET my_field = ?2, updated_at = CURRENT_TIMESTAMP, another = ?3 WHERE field = ?1',
-        ['test_where', 'test_data', '123'],
-        FetchTypes.ALL
-      )
+      expect.objectContaining({
+        query: 'UPDATE testTable SET my_field = ?2, updated_at = CURRENT_TIMESTAMP, another = ?3 WHERE field = ?1',
+        arguments: ['test_where', 'test_data', '123'],
+        fetchType: FetchTypes.ALL
+      })
     )
   })
 


### PR DESCRIPTION
@G4brym I identified a bug in my refactor allowing for batching of queries. I think the execute method needs to be passed nested in a lambda function; otherwise, the database is undefined when trying to make the query. 