### PR TITLE
Fix FetchOne() to start returning undefined when no results

### DIFF
--- a/src/databases/d1.ts
+++ b/src/databases/d1.ts
@@ -37,7 +37,7 @@ export class D1QB extends QueryBuilder<D1Result, D1ResultOne> {
         last_row_id: resp.meta?.last_row_id,
         served_by: resp.meta?.served_by,
         success: resp.success,
-        results: query.fetchType === FetchTypes.ONE && resp.results.length > 0 ? resp.results[0] : resp.results,
+        results: query.fetchType === FetchTypes.ONE ? resp.results[0] : resp.results,
       }
     }
 
@@ -64,7 +64,7 @@ export class D1QB extends QueryBuilder<D1Result, D1ResultOne> {
     return responses.map(
       (
         resp: {
-          results: any[] | null
+          results?: any[]
           success: boolean
           meta: {
             duration: number
@@ -82,10 +82,7 @@ export class D1QB extends QueryBuilder<D1Result, D1ResultOne> {
             last_row_id: resp.meta?.last_row_id,
             served_by: resp.meta?.served_by,
             success: resp.success,
-            results:
-              queryArray[i].fetchType === FetchTypes.ONE && resp.results && resp.results.length > 0
-                ? resp.results[0]
-                : resp.results,
+            results: queryArray[i].fetchType === FetchTypes.ONE ? resp.results?.[0] : resp.results,
           }
         } else {
           return {

--- a/src/databases/pg.ts
+++ b/src/databases/pg.ts
@@ -47,7 +47,7 @@ export class PGQB extends QueryBuilder<PGResult, PGResultOne> {
         command: result.command,
         lastRowId: result.oid,
         rowCount: result.rowCount,
-        results: query.fetchType === FetchTypes.ONE && result.rows.length > 0 ? result.rows[0] : result.rows,
+        results: query.fetchType === FetchTypes.ONE ? result.rows[0] : result.rows,
       }
     }
 


### PR DESCRIPTION
Previously when calling `FetchOne()` and no rows returned, the `result` property was an `[]` instead of `indefined`