### PR TITLE
Update top-level types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Zero dependencies Query Builder for Cloudflare Workers",
   "main": "./dist/workers-qb.js",
-  "types": "./dist/workers-qb.d.ts",
+  "types": "./dist/src/workers-qb.d.ts",
   "exports": {
     ".": {
       "types": "./dist/src/workers-qb.d.ts",


### PR DESCRIPTION
This PR fixes an issue where VS Code not being able to locate types when importing workers-qb. It updates the top-level `types` property in package.json, completing an earlier PR that only updated the `types` path under `exports`. 