### PR TITLE
Add dynamic selects

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ export default {
       })
       .execute()
 
+    // Or in a modular approach
+    const employeeList = await qb.select<Employee>('employees').where('active = ?', true).execute()
+
     // You get IDE type hints on each employee data, like:
     // employeeList.results[0].name
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workers-qb",
-  "version": "1.2.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workers-qb",
-      "version": "1.2.3",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workers-qb",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Zero dependencies Query Builder for Cloudflare Workers",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -66,7 +66,7 @@ export class QueryBuilder<GenericResultWrapper> {
   }
 
   select<GenericResult = DefaultReturnObject>(tableName: string): SelectBuilder<GenericResultWrapper, GenericResult> {
-    return new SelectBuilder(
+    return new SelectBuilder<GenericResultWrapper, GenericResult>(
       {
         tableName: tableName,
       },
@@ -423,16 +423,29 @@ export class QueryBuilder<GenericResultWrapper> {
     if (!value) return ''
     if (typeof value === 'string') return ` ORDER BY ${value}`
 
+    const order: Array<Record<string, string> | string> = []
     if (Array.isArray(value)) {
-      return ` ORDER BY ${value.join(', ')}`
+      for (const val of value) {
+        // @ts-ignore
+        order.push(val)
+      }
+    } else {
+      order.push(value)
     }
 
-    const order: Array<string> = []
-    Object.entries(value).forEach(([key, item]) => {
-      order.push(`${key} ${item}`)
+    const result = order.map((obj) => {
+      if (typeof obj === 'object') {
+        const objs: Array<string> = []
+        Object.entries(obj).forEach(([key, item]) => {
+          objs.push(`${key} ${item}`)
+        })
+        return objs.join(', ')
+      } else {
+        return obj
+      }
     })
 
-    return ` ORDER BY ${order.join(', ')}`
+    return ` ORDER BY ${result.join(', ')}`
   }
 
   _limit(value?: number): string {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -25,6 +25,7 @@ import {
 } from './interfaces'
 import { ConflictTypes, FetchTypes, OrderTypes } from './enums'
 import { Query, Raw } from './tools'
+import { SelectBuilder } from './modularBuilder'
 
 export class QueryBuilder<GenericResultWrapper> {
   _debugger = false
@@ -64,6 +65,17 @@ export class QueryBuilder<GenericResultWrapper> {
     }, `DROP TABLE ${params.ifExists ? 'IF EXISTS' : ''} ${params.tableName}`)
   }
 
+  select<GenericResult = DefaultReturnObject>(tableName: string): SelectBuilder<GenericResultWrapper, GenericResult> {
+    return new SelectBuilder(
+      {
+        tableName: tableName,
+      },
+      (params: SelectAll) => {
+        return this.fetchAll<GenericResult>(params)
+      }
+    )
+  }
+
   fetchOne<GenericResult = DefaultReturnObject>(
     params: SelectOne
   ): Query<OneResult<GenericResultWrapper, GenericResult>> {
@@ -73,7 +85,9 @@ export class QueryBuilder<GenericResultWrapper> {
       },
       this._select({ ...params, limit: 1 }),
       typeof params.where === 'object' && !Array.isArray(params.where) && params.where?.params
-        ? params.where?.params
+        ? Array.isArray(params.where?.params)
+          ? params.where?.params
+          : [params.where?.params]
         : undefined,
       FetchTypes.ONE
     )
@@ -88,7 +102,9 @@ export class QueryBuilder<GenericResultWrapper> {
       },
       this._select(params),
       typeof params.where === 'object' && !Array.isArray(params.where) && params.where?.params
-        ? params.where?.params
+        ? Array.isArray(params.where?.params)
+          ? params.where?.params
+          : [params.where?.params]
         : undefined,
       FetchTypes.ALL
     )
@@ -165,7 +181,11 @@ export class QueryBuilder<GenericResultWrapper> {
     let args = this._parse_arguments(params.data)
 
     if (typeof params.where === 'object' && !Array.isArray(params.where) && params.where?.params) {
-      args = (params.where?.params as Array<any>).concat(args)
+      if (Array.isArray(params.where?.params)) {
+        args = params.where?.params.concat(args)
+      } else {
+        args = [params.where?.params].concat(args)
+      }
     }
 
     return new Query(
@@ -189,7 +209,9 @@ export class QueryBuilder<GenericResultWrapper> {
       },
       this._delete(params),
       typeof params.where === 'object' && !Array.isArray(params.where) && params.where?.params
-        ? params.where?.params
+        ? Array.isArray(params.where?.params)
+          ? params.where?.params
+          : [params.where?.params]
         : undefined,
       FetchTypes.ALL
     )
@@ -251,7 +273,11 @@ export class QueryBuilder<GenericResultWrapper> {
         !Array.isArray(params.onConflict?.where) &&
         params.onConflict?.where?.params
       ) {
-        index += (params.onConflict.where?.params).length
+        if (Array.isArray(params.onConflict.where?.params)) {
+          index += (params.onConflict.where?.params).length
+        } else {
+          index += 1
+        }
       }
 
       if (params.onConflict.data) {
@@ -287,7 +313,9 @@ export class QueryBuilder<GenericResultWrapper> {
   _update(params: Update): string {
     const whereParamsLength: number =
       typeof params.where === 'object' && !Array.isArray(params.where) && params.where?.params
-        ? Object.keys(params.where?.params as Array<any>).length
+        ? Array.isArray(params.where?.params)
+          ? Object.keys(params.where?.params).length
+          : 1
         : 0
 
     const set: Array<string> = []
@@ -384,10 +412,11 @@ export class QueryBuilder<GenericResultWrapper> {
     return ` GROUP BY ${value.join(', ')}`
   }
 
-  _having(value?: string): string {
+  _having(value?: string | Array<string>): string {
     if (!value) return ''
+    if (typeof value === 'string') return ` HAVING ${value}`
 
-    return ` HAVING ${value}`
+    return ` HAVING ${value.join(' AND ')}`
   }
 
   _orderBy(value?: string | Array<string> | Record<string, string | OrderTypes>): string {

--- a/src/databases/d1.ts
+++ b/src/databases/d1.ts
@@ -1,4 +1,4 @@
-import { QueryBuilder } from '../Builder'
+import { QueryBuilder } from '../builder'
 import { FetchTypes } from '../enums'
 import { Query } from '../tools'
 import { D1Result } from '../interfaces'

--- a/src/databases/pg.ts
+++ b/src/databases/pg.ts
@@ -1,4 +1,4 @@
-import { QueryBuilder } from '../Builder'
+import { QueryBuilder } from '../builder'
 import { FetchTypes } from '../enums'
 import { Query } from '../tools'
 import { PGResult } from '../interfaces'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from './Builder'
+export * from './builder'
 export * from './databases/d1'
 export * from './databases/pg'
 export * from './enums'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,7 +11,7 @@ export type Where =
   | {
       conditions: string | Array<string>
       // TODO: enable named parameters with DefaultObject
-      params?: Primitive[]
+      params?: Primitive | Primitive[]
     }
   | string
   | Array<string>
@@ -29,7 +29,7 @@ export type SelectOne = {
   where?: Where
   join?: Join | Array<Join>
   groupBy?: string | Array<string>
-  having?: string
+  having?: string | Array<string>
   orderBy?: string | Array<string> | Record<string, string | OrderTypes>
   offset?: number
 }

--- a/src/modularBuilder.ts
+++ b/src/modularBuilder.ts
@@ -1,0 +1,119 @@
+import { ArrayResult, DefaultReturnObject, Primitive, SelectAll } from './interfaces'
+import { Query } from './tools'
+
+export class SelectBuilder<GenericResultWrapper, GenericResult = DefaultReturnObject> {
+  _debugger = false
+  _options: Partial<SelectAll> = {}
+  _queryBuilder: (params: SelectAll) => Query
+
+  constructor(options: Partial<SelectAll>, queryBuilder: (params: SelectAll) => Query) {
+    this._options = options
+    this._queryBuilder = queryBuilder
+  }
+
+  setDebugger(state: boolean): void {
+    this._debugger = state
+  }
+
+  async execute(): Promise<Query<ArrayResult<GenericResultWrapper, GenericResult>>['execute']> {
+    return this._queryBuilder(this._options as SelectAll).execute
+  }
+
+  tableName(tableName: SelectAll['tableName']): SelectBuilder<GenericResultWrapper> {
+    return new SelectBuilder<GenericResultWrapper>(
+      {
+        ...this._options,
+        tableName: tableName,
+      },
+      this._queryBuilder
+    )
+  }
+
+  fields(fields: SelectAll['fields']): SelectBuilder<GenericResultWrapper> {
+    return this._parseArray('fields', this._options.fields, fields)
+  }
+
+  where(conditions: string | Array<string>, params?: Primitive | Primitive[]): SelectBuilder<GenericResultWrapper> {
+    if (!Array.isArray(conditions)) {
+      conditions = [conditions]
+    }
+    if (params === undefined) params = []
+    if (!Array.isArray(params)) {
+      params = [params]
+    }
+
+    if ((this._options.where as any)?.conditions) {
+      conditions.concat((this._options.where as any).conditions)
+    }
+
+    if ((this._options.where as any)?.params) {
+      params.concat((this._options.where as any).params)
+    }
+
+    return new SelectBuilder<GenericResultWrapper>(
+      {
+        ...this._options,
+        where: {
+          conditions: conditions,
+          params: params,
+        },
+      },
+      this._queryBuilder
+    )
+  }
+
+  join(join: SelectAll['join']): SelectBuilder<GenericResultWrapper> {
+    return this._parseArray('join', this._options.join, join)
+  }
+
+  groupBy(groupBy: SelectAll['groupBy']): SelectBuilder<GenericResultWrapper> {
+    return this._parseArray('groupBy', this._options.groupBy, groupBy)
+  }
+
+  having(having: SelectAll['having']): SelectBuilder<GenericResultWrapper> {
+    return this._parseArray('having', this._options.having, having)
+  }
+
+  orderBy(orderBy: SelectAll['orderBy']): SelectBuilder<GenericResultWrapper> {
+    return this._parseArray('orderBy', this._options.orderBy, orderBy)
+  }
+
+  offset(offset: SelectAll['offset']): SelectBuilder<GenericResultWrapper> {
+    return new SelectBuilder<GenericResultWrapper>(
+      {
+        ...this._options,
+        offset: offset,
+      },
+      this._queryBuilder
+    )
+  }
+
+  limit(limit: SelectAll['limit']): SelectBuilder<GenericResultWrapper> {
+    return new SelectBuilder<GenericResultWrapper>(
+      {
+        ...this._options,
+        limit: limit,
+      },
+      this._queryBuilder
+    )
+  }
+
+  _parseArray(fieldName: string, option: any, value: any): SelectBuilder<GenericResultWrapper> {
+    let val = []
+    if (!Array.isArray(value)) {
+      val.push(value)
+    }
+
+    if (option && Array.isArray(option)) {
+      val = [...option, ...val]
+    }
+
+    return new SelectBuilder<GenericResultWrapper>(
+      {
+        ...this._options,
+        [fieldName]: val as Array<string>,
+      },
+      this._queryBuilder
+    )
+  }
+}

--- a/tests/builder/select.test.ts
+++ b/tests/builder/select.test.ts
@@ -320,6 +320,25 @@ describe('Select Builder', () => {
     expect(result.fetchType).toEqual('ALL')
   })
 
+  test('select with multiple where and one group by and multiple having', async () => {
+    const result = new QuerybuilderTest().fetchAll({
+      tableName: 'testTable',
+      fields: '*',
+      where: {
+        conditions: ['field = ?1', 'test = ?2'],
+        params: ['test', 123],
+      },
+      groupBy: 'type',
+      having: ['COUNT(trackid) > 15', 'COUNT(trackid) < 30'],
+    })
+
+    expect(trimQuery(result.query)).toEqual(
+      'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type HAVING COUNT(trackid) > 15 AND COUNT(trackid) < 30'
+    )
+    expect(result.arguments).toEqual(['test', 123])
+    expect(result.fetchType).toEqual('ALL')
+  })
+
   test('select with multiple where and one group by and one order by', async () => {
     const result = new QuerybuilderTest().fetchAll({
       tableName: 'testTable',

--- a/tests/builder/select.test.ts
+++ b/tests/builder/select.test.ts
@@ -3,419 +3,606 @@ import { JoinTypes, OrderTypes } from '../../src/enums'
 
 describe('Select Builder', () => {
   test('select simple', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable')
-    expect(result.arguments).toBeUndefined()
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+      }),
+      new QuerybuilderTest().select('testTable').fields('*').getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable')
+      expect(result.arguments).toBeUndefined()
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select fields default value', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable')
-    expect(result.arguments).toBeUndefined()
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+      }),
+      new QuerybuilderTest().select('testTable').getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable')
+      expect(result.arguments).toBeUndefined()
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select fields default value one', async () => {
-    const result = new QuerybuilderTest().fetchOne({
-      tableName: 'testTable',
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable LIMIT 1')
-    expect(result.arguments).toBeUndefined()
-    expect(result.fetchType).toEqual('ONE')
+    for (const result of [
+      new QuerybuilderTest().fetchOne({
+        tableName: 'testTable',
+      }),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable LIMIT 1')
+      expect(result.arguments).toBeUndefined()
+      expect(result.fetchType).toEqual('ONE')
+    }
   })
 
   test('select with one where', async () => {
-    const result = new QuerybuilderTest().fetchOne({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: 'field = ?1',
-        params: ['test'],
-      },
-    })
+    for (const result of [
+      new QuerybuilderTest().fetchOne({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: 'field = ?1',
+          params: ['test'],
+        },
+      }),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = ?1 LIMIT 1')
+      expect(result.arguments).toEqual(['test'])
+      expect(result.fetchType).toEqual('ONE')
+    }
   })
 
   test('select with simplified where', async () => {
-    const result = new QuerybuilderTest().fetchOne({
-      tableName: 'testTable',
-      fields: '*',
-      where: 'field = true',
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = true LIMIT 1')
-    expect(result.arguments).toEqual(undefined)
-    expect(result.fetchType).toEqual('ONE')
+    for (const result of [
+      new QuerybuilderTest().fetchOne({
+        tableName: 'testTable',
+        fields: '*',
+        where: 'field = true',
+      }),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = true LIMIT 1')
+      expect(result.arguments).toEqual(undefined)
+      expect(result.fetchType).toEqual('ONE')
+    }
   })
 
   test('select with empty where', async () => {
-    const result = new QuerybuilderTest().fetchOne({
-      tableName: 'testTable',
-      fields: '*',
-      // @ts-ignore
-      where: null,
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable LIMIT 1')
-    expect(result.arguments).toEqual(undefined)
-    expect(result.fetchType).toEqual('ONE')
+    for (const result of [
+      new QuerybuilderTest().fetchOne({
+        tableName: 'testTable',
+        fields: '*',
+        // @ts-ignore
+        where: null,
+      }),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable LIMIT 1')
+      expect(result.arguments).toEqual(undefined)
+      expect(result.fetchType).toEqual('ONE')
+    }
   })
 
   test('select with empty where 2', async () => {
-    const result = new QuerybuilderTest().fetchOne({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: [],
-        params: [],
-      },
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable LIMIT 1')
-    expect(result.arguments).toEqual([])
-    expect(result.fetchType).toEqual('ONE')
+    for (const result of [
+      new QuerybuilderTest().fetchOne({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: [],
+          params: [],
+        },
+      }),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable LIMIT 1')
+      expect(result.arguments).toEqual([])
+      expect(result.fetchType).toEqual('ONE')
+    }
   })
 
   test('select with simplified where list', async () => {
-    const result = new QuerybuilderTest().fetchOne({
-      tableName: 'testTable',
-      fields: '*',
-      where: ['field = true', 'active = false'],
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = true AND active = false LIMIT 1')
-    expect(result.arguments).toEqual(undefined)
-    expect(result.fetchType).toEqual('ONE')
+    for (const result of [
+      new QuerybuilderTest().fetchOne({
+        tableName: 'testTable',
+        fields: '*',
+        where: ['field = true', 'active = false'],
+      }),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = true AND active = false LIMIT 1')
+      expect(result.arguments).toEqual(undefined)
+      expect(result.fetchType).toEqual('ONE')
+    }
   })
 
   test('select with simple join', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: 'field = ?1',
-        params: ['test'],
-      },
-      join: {
-        table: 'employees',
-        on: 'testTable.employee_id = employees.id',
-      },
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable JOIN employees ON testTable.employee_id = employees.id ' + 'WHERE field = ?1'
-    )
-    expect(result.arguments).toEqual(['test'])
-    expect(result.fetchType).toEqual('ALL')
-  })
-
-  test('select with multiple joins', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: 'field = ?1',
-        params: ['test'],
-      },
-      join: [
-        {
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: 'field = ?1',
+          params: ['test'],
+        },
+        join: {
           table: 'employees',
           on: 'testTable.employee_id = employees.id',
         },
-        {
-          table: 'offices',
-          on: 'testTable.office_id = offices.id',
-        },
-      ],
-    })
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .join({ table: 'employees', on: 'testTable.employee_id = employees.id' })
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable JOIN employees ON testTable.employee_id = employees.id ' + 'WHERE field = ?1'
+      )
+      expect(result.arguments).toEqual(['test'])
+      expect(result.fetchType).toEqual('ALL')
+    }
+  })
 
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable' +
-        ' JOIN employees ON testTable.employee_id = employees.id' +
-        ' JOIN offices ON testTable.office_id = offices.id' +
-        ' WHERE field = ?1'
-    )
-    expect(result.arguments).toEqual(['test'])
-    expect(result.fetchType).toEqual('ALL')
+  test('select with multiple joins', async () => {
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: 'field = ?1',
+          params: ['test'],
+        },
+        join: [
+          {
+            table: 'employees',
+            on: 'testTable.employee_id = employees.id',
+          },
+          {
+            table: 'offices',
+            on: 'testTable.office_id = offices.id',
+          },
+        ],
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .join({ table: 'employees', on: 'testTable.employee_id = employees.id' })
+        .join({ table: 'offices', on: 'testTable.office_id = offices.id' })
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable' +
+          ' JOIN employees ON testTable.employee_id = employees.id' +
+          ' JOIN offices ON testTable.office_id = offices.id' +
+          ' WHERE field = ?1'
+      )
+      expect(result.arguments).toEqual(['test'])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with left join', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: 'field = ?1',
-        params: ['test'],
-      },
-      join: {
-        type: JoinTypes.LEFT,
-        table: 'employees',
-        on: 'testTable.employee_id = employees.id',
-      },
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable LEFT JOIN employees ON testTable.employee_id = employees.id WHERE field = ?1'
-    )
-    expect(result.arguments).toEqual(['test'])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: 'field = ?1',
+          params: ['test'],
+        },
+        join: {
+          type: JoinTypes.LEFT,
+          table: 'employees',
+          on: 'testTable.employee_id = employees.id',
+        },
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .join({ type: JoinTypes.LEFT, table: 'employees', on: 'testTable.employee_id = employees.id' })
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable LEFT JOIN employees ON testTable.employee_id = employees.id WHERE field = ?1'
+      )
+      expect(result.arguments).toEqual(['test'])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with subquery join', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: 'field = ?1',
-        params: ['test'],
-      },
-      join: {
-        table: {
-          tableName: 'otherTable',
-          fields: ['test_table_id', 'GROUP_CONCAT(attribute) AS attributes'],
-          groupBy: 'test_table_id',
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: 'field = ?1',
+          params: ['test'],
         },
-        on: 'testTable.id = otherTableGrouped.test_table_id',
-        alias: 'otherTableGrouped',
-      },
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable JOIN (SELECT test_table_id, GROUP_CONCAT(attribute) ' +
-        'AS attributes FROM otherTable GROUP BY test_table_id) AS otherTableGrouped ON testTable.id = otherTableGrouped.' +
-        'test_table_id WHERE field = ?1'
-    )
-    expect(result.arguments).toEqual(['test'])
-    expect(result.fetchType).toEqual('ALL')
+        join: {
+          table: {
+            tableName: 'otherTable',
+            fields: ['test_table_id', 'GROUP_CONCAT(attribute) AS attributes'],
+            groupBy: 'test_table_id',
+          },
+          on: 'testTable.id = otherTableGrouped.test_table_id',
+          alias: 'otherTableGrouped',
+        },
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .join({
+          table: {
+            tableName: 'otherTable',
+            fields: ['test_table_id', 'GROUP_CONCAT(attribute) AS attributes'],
+            groupBy: 'test_table_id',
+          },
+          on: 'testTable.id = otherTableGrouped.test_table_id',
+          alias: 'otherTableGrouped',
+        })
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable JOIN (SELECT test_table_id, GROUP_CONCAT(attribute) ' +
+          'AS attributes FROM otherTable GROUP BY test_table_id) AS otherTableGrouped ON testTable.id = otherTableGrouped.' +
+          'test_table_id WHERE field = ?1'
+      )
+      expect(result.arguments).toEqual(['test'])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with nested subquery joins', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: 'field = ?1',
-        params: ['test'],
-      },
-      join: {
-        table: {
-          tableName: 'otherTable',
-          fields: [
-            'test_table_id',
-            'GROUP_CONCAT(attribute) AS attributes',
-            'GROUP_CONCAT(other_attributes, ";") AS other_attributes',
-          ],
-          groupBy: 'test_table_id',
-          join: {
-            table: {
-              tableName: 'otherTableTwo',
-              fields: ['other_table_id', 'GROUP_CONCAT(other_attribute) AS other_attributes'],
-              groupBy: 'other_table_id',
-            },
-            on: 'otherTable.id = otherTableTwoGrouped.other_table_id',
-            alias: 'otherTableTwoGrouped',
-          },
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: 'field = ?1',
+          params: ['test'],
         },
-        on: 'testTable.id = otherTableGrouped.test_table_id',
-        alias: 'otherTableGrouped',
-      },
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable JOIN (SELECT test_table_id, GROUP_CONCAT(attribute) ' +
-        'AS attributes, GROUP_CONCAT(other_attributes, ";") AS other_attributes FROM otherTable JOIN ' +
-        '(SELECT other_table_id, GROUP_CONCAT(other_attribute) AS other_attributes FROM otherTableTwo ' +
-        'GROUP BY other_table_id) AS otherTableTwoGrouped ON otherTable.id = otherTableTwoGrouped.other_table_id ' +
-        'GROUP BY test_table_id) AS otherTableGrouped ON testTable.id = otherTableGrouped.test_table_id WHERE field = ?1'
-    )
-    expect(result.arguments).toEqual(['test'])
-    expect(result.fetchType).toEqual('ALL')
+        join: {
+          table: {
+            tableName: 'otherTable',
+            fields: [
+              'test_table_id',
+              'GROUP_CONCAT(attribute) AS attributes',
+              'GROUP_CONCAT(other_attributes, ";") AS other_attributes',
+            ],
+            groupBy: 'test_table_id',
+            join: {
+              table: {
+                tableName: 'otherTableTwo',
+                fields: ['other_table_id', 'GROUP_CONCAT(other_attribute) AS other_attributes'],
+                groupBy: 'other_table_id',
+              },
+              on: 'otherTable.id = otherTableTwoGrouped.other_table_id',
+              alias: 'otherTableTwoGrouped',
+            },
+          },
+          on: 'testTable.id = otherTableGrouped.test_table_id',
+          alias: 'otherTableGrouped',
+        },
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .join({
+          table: {
+            tableName: 'otherTable',
+            fields: [
+              'test_table_id',
+              'GROUP_CONCAT(attribute) AS attributes',
+              'GROUP_CONCAT(other_attributes, ";") AS other_attributes',
+            ],
+            groupBy: 'test_table_id',
+            join: {
+              table: {
+                tableName: 'otherTableTwo',
+                fields: ['other_table_id', 'GROUP_CONCAT(other_attribute) AS other_attributes'],
+                groupBy: 'other_table_id',
+              },
+              on: 'otherTable.id = otherTableTwoGrouped.other_table_id',
+              alias: 'otherTableTwoGrouped',
+            },
+          },
+          on: 'testTable.id = otherTableGrouped.test_table_id',
+          alias: 'otherTableGrouped',
+        })
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable JOIN (SELECT test_table_id, GROUP_CONCAT(attribute) ' +
+          'AS attributes, GROUP_CONCAT(other_attributes, ";") AS other_attributes FROM otherTable JOIN ' +
+          '(SELECT other_table_id, GROUP_CONCAT(other_attribute) AS other_attributes FROM otherTableTwo ' +
+          'GROUP BY other_table_id) AS otherTableTwoGrouped ON otherTable.id = otherTableTwoGrouped.other_table_id ' +
+          'GROUP BY test_table_id) AS otherTableGrouped ON testTable.id = otherTableGrouped.test_table_id WHERE field = ?1'
+      )
+      expect(result.arguments).toEqual(['test'])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with one where no parameters', async () => {
-    const result = new QuerybuilderTest().fetchOne({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: "field = 'test'",
-      },
-    })
-
-    expect(trimQuery(result.query)).toEqual("SELECT * FROM testTable WHERE field = 'test' LIMIT 1")
-    expect(result.arguments).toBeUndefined()
-    expect(result.fetchType).toEqual('ONE')
+    for (const result of [
+      new QuerybuilderTest().fetchOne({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: "field = 'test'",
+        },
+      }),
+    ]) {
+      expect(trimQuery(result.query)).toEqual("SELECT * FROM testTable WHERE field = 'test' LIMIT 1")
+      expect(result.arguments).toBeUndefined()
+      expect(result.fetchType).toEqual('ONE')
+    }
   })
 
   test('select with multiple where', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = ?1 AND test = ?2')
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?', 'test = ?'],
+          params: ['test', 123],
+        },
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?', 'test')
+        .where('test = ?', 123)
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = ? AND test = ?')
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with multiple where and one group by', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-      groupBy: 'type',
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type')
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?1', 'test = ?2'],
+          params: ['test', 123],
+        },
+        groupBy: 'type',
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .where('test = ?2', 123)
+        .groupBy('type')
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type')
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with multiple where and multiple group by', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-      groupBy: ['type', 'day'],
-    })
-
-    expect(trimQuery(result.query)).toEqual('SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type, day')
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?1', 'test = ?2'],
+          params: ['test', 123],
+        },
+        groupBy: ['type', 'day'],
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .where('test = ?2', 123)
+        .groupBy('type')
+        .groupBy('day')
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type, day'
+      )
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with multiple where and one group by and having', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-      groupBy: 'type',
-      having: 'COUNT(trackid) > 15',
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type HAVING COUNT(trackid) > 15'
-    )
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?1', 'test = ?2'],
+          params: ['test', 123],
+        },
+        groupBy: 'type',
+        having: 'COUNT(trackid) > 15',
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .where('test = ?2', 123)
+        .groupBy('type')
+        .having('COUNT(trackid) > 15')
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type HAVING COUNT(trackid) > 15'
+      )
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with multiple where and one group by and multiple having', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-      groupBy: 'type',
-      having: ['COUNT(trackid) > 15', 'COUNT(trackid) < 30'],
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type HAVING COUNT(trackid) > 15 AND COUNT(trackid) < 30'
-    )
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?1', 'test = ?2'],
+          params: ['test', 123],
+        },
+        groupBy: 'type',
+        having: ['COUNT(trackid) > 15', 'COUNT(trackid) < 30'],
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .where('test = ?2', 123)
+        .groupBy('type')
+        .having('COUNT(trackid) > 15')
+        .having('COUNT(trackid) < 30')
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type HAVING COUNT(trackid) > 15 AND COUNT(trackid) < 30'
+      )
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with multiple where and one group by and one order by', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-      groupBy: 'type',
-      orderBy: 'id',
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type ORDER BY id'
-    )
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?1', 'test = ?2'],
+          params: ['test', 123],
+        },
+        groupBy: 'type',
+        orderBy: 'id',
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .where('test = ?2', 123)
+        .groupBy('type')
+        .orderBy('id')
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type ORDER BY id'
+      )
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with multiple where and one group by and multiple order by', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-      groupBy: 'type',
-      orderBy: ['id', 'timestamp'],
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type ORDER BY id, timestamp'
-    )
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?1', 'test = ?2'],
+          params: ['test', 123],
+        },
+        groupBy: 'type',
+        orderBy: ['id', 'timestamp'],
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .where('test = ?2', 123)
+        .groupBy('type')
+        .orderBy('id')
+        .orderBy('timestamp')
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type ORDER BY id, timestamp'
+      )
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with multiple where and one group by and object order by', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-      groupBy: 'type',
-      orderBy: {
-        id: 'ASC',
-        timestamp: OrderTypes.DESC,
-      },
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type ORDER BY id ASC, timestamp DESC'
-    )
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?1', 'test = ?2'],
+          params: ['test', 123],
+        },
+        groupBy: 'type',
+        orderBy: {
+          id: 'ASC',
+          timestamp: OrderTypes.DESC,
+        },
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .where('test = ?2', 123)
+        .groupBy('type')
+        .orderBy({ id: 'ASC' })
+        .orderBy({ timestamp: OrderTypes.DESC })
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type ORDER BY id ASC, timestamp DESC'
+      )
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 
   test('select with multiple where and one group by and limit and offset', async () => {
-    const result = new QuerybuilderTest().fetchAll({
-      tableName: 'testTable',
-      fields: '*',
-      where: {
-        conditions: ['field = ?1', 'test = ?2'],
-        params: ['test', 123],
-      },
-      groupBy: 'type',
-      limit: 10,
-      offset: 15,
-    })
-
-    expect(trimQuery(result.query)).toEqual(
-      'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type LIMIT 10 OFFSET 15'
-    )
-    expect(result.arguments).toEqual(['test', 123])
-    expect(result.fetchType).toEqual('ALL')
+    for (const result of [
+      new QuerybuilderTest().fetchAll({
+        tableName: 'testTable',
+        fields: '*',
+        where: {
+          conditions: ['field = ?1', 'test = ?2'],
+          params: ['test', 123],
+        },
+        groupBy: 'type',
+        limit: 10,
+        offset: 15,
+      }),
+      new QuerybuilderTest()
+        .select('testTable')
+        .fields('*')
+        .where('field = ?1', 'test')
+        .where('test = ?2', 123)
+        .groupBy('type')
+        .limit(10)
+        .offset(15)
+        .getQuery(),
+    ]) {
+      expect(trimQuery(result.query)).toEqual(
+        'SELECT * FROM testTable WHERE field = ?1 AND test = ?2 GROUP BY type LIMIT 10 OFFSET 15'
+      )
+      expect(result.arguments).toEqual(['test', 123])
+      expect(result.fetchType).toEqual('ALL')
+    }
   })
 })

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,4 @@
-import { QueryBuilder } from '../src/Builder'
+import { QueryBuilder } from '../src/builder'
 import { Query } from '../src/tools'
 import { D1Result } from '../src/interfaces'
 


### PR DESCRIPTION
New select interface allows developers to chain the select fields:
```ts
const qb = new D1QB(env.DB)

const result = await qb.select('my-table')
                        .where('active = ?', true)
                        .where('department = ?', 'HR')
                        .orderBy('id')
                        .execute()
```