### PR TITLE
Add count method to selects

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -24,7 +24,7 @@ import {
   Where,
 } from './interfaces'
 import { ConflictTypes, FetchTypes, OrderTypes } from './enums'
-import { Query, Raw } from './tools'
+import { Query, QueryWithExtra, Raw } from './tools'
 import { SelectBuilder } from './modularBuilder'
 
 export class QueryBuilder<GenericResultWrapper> {
@@ -78,12 +78,17 @@ export class QueryBuilder<GenericResultWrapper> {
 
   fetchOne<GenericResult = DefaultReturnObject>(
     params: SelectOne
-  ): Query<OneResult<GenericResultWrapper, GenericResult>> {
-    return new Query(
+  ): QueryWithExtra<GenericResultWrapper, OneResult<GenericResultWrapper, GenericResult>> {
+    return new QueryWithExtra(
       (q: Query) => {
         return this.execute(q)
       },
       this._select({ ...params, limit: 1 }),
+      this._select({
+        ...params,
+        fields: 'count(*) as total',
+        limit: 1,
+      }),
       typeof params.where === 'object' && !Array.isArray(params.where) && params.where?.params
         ? Array.isArray(params.where?.params)
           ? params.where?.params
@@ -95,12 +100,17 @@ export class QueryBuilder<GenericResultWrapper> {
 
   fetchAll<GenericResult = DefaultReturnObject>(
     params: SelectAll
-  ): Query<ArrayResult<GenericResultWrapper, GenericResult>> {
-    return new Query(
+  ): QueryWithExtra<GenericResultWrapper, ArrayResult<GenericResultWrapper, GenericResult>> {
+    return new QueryWithExtra(
       (q: Query) => {
         return this.execute(q)
       },
       this._select(params),
+      this._select({
+        ...params,
+        fields: 'count(*) as total',
+        limit: 1,
+      }),
       typeof params.where === 'object' && !Array.isArray(params.where) && params.where?.params
         ? Array.isArray(params.where?.params)
           ? params.where?.params

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -135,3 +135,5 @@ export type PGResult = {
 
 export type ArrayResult<ResultWrapper, Result> = Merge<ResultWrapper, { results?: Array<Result> }>
 export type OneResult<ResultWrapper, Result> = Merge<ResultWrapper, { results?: Result }>
+
+export type CountResult<GenericResultWrapper> = OneResult<GenericResultWrapper, { total: number }>

--- a/src/modularBuilder.ts
+++ b/src/modularBuilder.ts
@@ -1,12 +1,12 @@
-import { ArrayResult, DefaultReturnObject, Primitive, SelectAll } from './interfaces'
-import { Query } from './tools'
+import { ArrayResult, CountResult, DefaultReturnObject, Primitive, SelectAll } from './interfaces'
+import { Query, QueryWithExtra } from './tools'
 
 export class SelectBuilder<GenericResultWrapper, GenericResult = DefaultReturnObject> {
   _debugger = false
   private _options: Partial<SelectAll> = {}
-  private _queryBuilder: (params: SelectAll) => Query
+  private _queryBuilder: (params: SelectAll) => QueryWithExtra<GenericResultWrapper>
 
-  constructor(options: Partial<SelectAll>, queryBuilder: (params: SelectAll) => Query) {
+  constructor(options: Partial<SelectAll>, queryBuilder: (params: SelectAll) => QueryWithExtra<GenericResultWrapper>) {
     this._options = options
     this._queryBuilder = queryBuilder
   }
@@ -124,5 +124,9 @@ export class SelectBuilder<GenericResultWrapper, GenericResult = DefaultReturnOb
 
   async execute(): Promise<ArrayResult<GenericResultWrapper, GenericResult>> {
     return this._queryBuilder(this._options as SelectAll).execute()
+  }
+
+  async count(): Promise<CountResult<GenericResultWrapper>> {
+    return this._queryBuilder(this._options as SelectAll).count()
   }
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,5 +1,5 @@
 import { FetchTypes } from './enums'
-import { Primitive } from './interfaces'
+import { CountResult, Primitive } from './interfaces'
 
 export class Raw {
   public isRaw = true
@@ -10,7 +10,7 @@ export class Raw {
 }
 
 export class Query<Result = any> {
-  executeMethod: (query: Query<Result>) => Promise<Result>
+  public executeMethod: (query: Query<Result>) => Promise<Result>
   public query: string
   public arguments?: Primitive[]
   public fetchType?: FetchTypes
@@ -29,5 +29,26 @@ export class Query<Result = any> {
 
   async execute(): Promise<Result> {
     return this.executeMethod(this)
+  }
+}
+
+export class QueryWithExtra<GenericResultWrapper, Result = any> extends Query<Result> {
+  private countQuery: string
+
+  constructor(
+    executeMethod: (query: Query<Result>) => Promise<Result>,
+    query: string,
+    countQuery: string,
+    args?: Primitive[],
+    fetchType?: FetchTypes
+  ) {
+    super(executeMethod, query, args, fetchType)
+    this.countQuery = countQuery
+  }
+
+  async count(): Promise<CountResult<GenericResultWrapper>> {
+    return this.executeMethod(
+      new Query(this.executeMethod, this.countQuery, this.arguments, FetchTypes.ONE)
+    ) as Promise<CountResult<GenericResultWrapper>>
   }
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -2,12 +2,15 @@ import { QueryBuilder } from '../src/builder'
 import { Query } from '../src/tools'
 import { D1Result } from '../src/interfaces'
 
-export class QuerybuilderTest extends QueryBuilder<D1Result> {
-  async execute(query: Query) {
+export class QuerybuilderTest extends QueryBuilder<{}> {
+  async execute(query: Query): Promise<Query<any>> {
     return {
-      duration: 0,
-      success: true,
-      served_by: 'test',
+      // @ts-ignore
+      results: {
+        query: query.query,
+        arguments: query.arguments,
+        fetchType: query.fetchType,
+      },
     }
   }
 }


### PR DESCRIPTION
```ts
  const qs = await qb.select('testTable')
        .fields('*')
        .where('field = ?1', 'test')
        .join({ table: 'employees', on: 'testTable.employee_id = employees.id' })
        .join({ table: 'offices', on: 'testTable.office_id = offices.id' })
        .count(),
  
  console.log(`total is ${qs.results.total}`)
```