### PR TITLE
feat: add `executeSync` in qb and in DODB

### DIFF
--- a/docs/pages/databases/cloudflare-do.md
+++ b/docs/pages/databases/cloudflare-do.md
@@ -15,6 +15,21 @@ export class DOSRS extends DurableObject {
       })
       .execute()
 
+    // you can also use `transaction`, which is useful for multiple queries:
+    this.ctx.storage.transactionSync(() => {
+      // `executeSync` blocks synchronously until the query has been executed
+      // this is avaliable on DODB (and might not be on other providers)
+      const fetched = qb
+        .fetchAll({
+          tableName: 'employees',
+        })
+        .executeSync()
+
+      const result = fetched.map((val) => qb.select('payments').where('name = ?', val.name).executeSync())
+
+      return result
+    })
+
     return fetched.results
   }
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -74,6 +74,10 @@ export class QueryBuilder<GenericResultWrapper> {
     throw new Error('Execute method not implemented')
   }
 
+  executeSync(query: Query): any {
+    throw new Error('"executeSync" method not implemented')
+  }
+
   async batchExecute(queryArray: Query[]): Promise<any[]> {
     throw new Error('Batch execute method not implemented')
   }
@@ -88,7 +92,12 @@ export class QueryBuilder<GenericResultWrapper> {
         return this.execute(q)
       },
       `CREATE TABLE ${params.ifNotExists ? 'IF NOT EXISTS' : ''} ${params.tableName}
-      ( ${params.schema})`
+      ( ${params.schema})`,
+      undefined,
+      undefined,
+      (q: Query) => {
+        return this.executeSync(q)
+      }
     )
   }
 
@@ -96,9 +105,17 @@ export class QueryBuilder<GenericResultWrapper> {
     tableName: string
     ifExists?: boolean
   }): Query<ArrayResult<GenericResultWrapper, GenericResult>> {
-    return new Query((q: Query) => {
-      return this.execute(q)
-    }, `DROP TABLE ${params.ifExists ? 'IF EXISTS' : ''} ${params.tableName}`)
+    return new Query(
+      (q: Query) => {
+        return this.execute(q)
+      },
+      `DROP TABLE ${params.ifExists ? 'IF EXISTS' : ''} ${params.tableName}`,
+      undefined,
+      undefined,
+      (q: Query) => {
+        return this.executeSync(q)
+      }
+    )
   }
 
   select<GenericResult = DefaultReturnObject>(tableName: string): SelectBuilder<GenericResultWrapper, GenericResult> {
@@ -134,7 +151,10 @@ export class QueryBuilder<GenericResultWrapper> {
           ? params.where?.params
           : [params.where?.params]
         : undefined,
-      FetchTypes.ONE
+      FetchTypes.ONE,
+      (q: Query) => {
+        return this.executeSync(q)
+      }
     )
   }
 
@@ -157,7 +177,10 @@ export class QueryBuilder<GenericResultWrapper> {
           ? params.where?.params
           : [params.where?.params]
         : undefined,
-      FetchTypes.ALL
+      FetchTypes.ALL,
+      (q: Query) => {
+        return this.executeSync(q)
+      }
     )
   }
 
@@ -175,7 +198,10 @@ export class QueryBuilder<GenericResultWrapper> {
       },
       params.query,
       params.args,
-      params.fetchType
+      params.fetchType,
+      (q: Query) => {
+        return this.executeSync(q)
+      }
     )
   }
 
@@ -220,7 +246,10 @@ export class QueryBuilder<GenericResultWrapper> {
       },
       this._insert(params),
       args,
-      fetchType
+      fetchType,
+      (q: Query) => {
+        return this.executeSync(q)
+      }
     )
   }
 
@@ -245,7 +274,10 @@ export class QueryBuilder<GenericResultWrapper> {
       },
       this._update(params),
       args,
-      FetchTypes.ALL
+      FetchTypes.ALL,
+      (q: Query) => {
+        return this.executeSync(q)
+      }
     )
   }
 
@@ -264,7 +296,10 @@ export class QueryBuilder<GenericResultWrapper> {
           ? params.where?.params
           : [params.where?.params]
         : undefined,
-      FetchTypes.ALL
+      FetchTypes.ALL,
+      (q: Query) => {
+        return this.executeSync(q)
+      }
     )
   }
 

--- a/src/databases/do.ts
+++ b/src/databases/do.ts
@@ -11,36 +11,50 @@ export class DOQB extends QueryBuilder<{}> {
     this.db = db
   }
 
-  async execute(query: Query) {
-    return await this.loggerWrapper(query, async () => {
-      if (query.arguments) {
-        let stmt = this.db.prepare(query.query)
-        // @ts-expect-error Their types appear to be wrong here
-        const result = stmt(...query.arguments) as SqlStorageCursor
-        if (query.fetchType == FetchTypes.ONE) {
-          return {
-            results: Array.from(result)[0],
-          }
-        }
-
-        // by default return everything
-        return {
-          results: Array.from(result),
-        }
-      }
-
-      const cursor = this.db.exec(query.query)
-
+  /**
+   * Usually DB calls are async by their own nature (because it communicates with another machine or another process)
+   * In this case, SRS is running SQLite locally in the same thread, which means that query executes are synchronous
+   * and blocking.
+   */
+  #execute(query: Query): any {
+    if (query.arguments) {
+      const stmt = this.db.prepare(query.query)
+      // @ts-expect-error Their types appear to be wrong here
+      const result = stmt(...query.arguments) as SqlStorageCursor
       if (query.fetchType == FetchTypes.ONE) {
         return {
-          results: Array.from(cursor)[0],
+          results: Array.from(result)[0],
         }
       }
 
       // by default return everything
       return {
-        results: Array.from(cursor),
+        results: Array.from(result),
       }
+    }
+
+    const cursor = this.db.exec(query.query)
+
+    if (query.fetchType == FetchTypes.ONE) {
+      return {
+        results: Array.from(cursor)[0],
+      }
+    }
+
+    // by default return everything
+    return {
+      results: Array.from(cursor),
+    }
+  }
+
+  async execute(query: Query): Promise<any> {
+    return await this.loggerWrapper(query, async () => {
+      return this.#execute(query)
     })
+  }
+
+  executeSync(query: Query): any {
+    //TODO(lduarte): make logger sync too
+    return this.#execute(query)
   }
 }


### PR DESCRIPTION
Usually DB calls are async by their own nature (because it communicates with another machine or another process)
In this case, SRS is running SQLite locally in the same thread, which means that query executes are synchronous
and blocking. This is particularly useful to make multiple queries using the SRS `transactionSync` method. 

This makes database adapters to optionally provide `executeSync` for it and change query builders to support sync execution with `query.executeSync()`