### PR TITLE
Fix failing tests for cross join and raw queries

### DIFF
--- a/tests/integration/migrations-d1.test.ts
+++ b/tests/integration/migrations-d1.test.ts
@@ -23,7 +23,7 @@ describe('Migrations', () => {
         await env.DB.prepare(`SELECT name
                                   FROM sqlite_master
                                   WHERE type = 'table'`).all()
-      ).results
+      ).results.filter((table: any) => table.name !== '_cf_METADATA')
     ).toEqual([])
 
     await qb.migrations({ migrations }).initialize()
@@ -34,7 +34,7 @@ describe('Migrations', () => {
                                   FROM sqlite_master
                                   WHERE type = 'table'
                                     AND name <> 'sqlite_sequence'`).all()
-      ).results
+      ).results.filter((table: any) => table.name !== '_cf_METADATA')
     ).toEqual([
       {
         name: 'migrations',
@@ -50,7 +50,7 @@ describe('Migrations', () => {
         await env.DB.prepare(`SELECT name
                                   FROM sqlite_master
                                   WHERE type = 'table'`).all()
-      ).results
+      ).results.filter((table: any) => table.name !== '_cf_METADATA')
     ).toEqual([])
 
     const applyResp = await qb.migrations({ migrations }).apply()
@@ -64,7 +64,7 @@ describe('Migrations', () => {
                                   FROM sqlite_master
                                   WHERE type = 'table'
                                     AND name <> 'sqlite_sequence'`).all()
-      ).results
+      ).results.filter((table: any) => table.name !== '_cf_METADATA')
     ).toEqual([
       {
         name: 'migrations',
@@ -86,7 +86,7 @@ describe('Migrations', () => {
         await env.DB.prepare(`SELECT name
                                   FROM sqlite_master
                                   WHERE type = 'table'`).all()
-      ).results
+      ).results.filter((table: any) => table.name !== '_cf_METADATA')
     ).toEqual([])
 
     const applyResp = await qb.migrations({ migrations }).apply()
@@ -100,7 +100,7 @@ describe('Migrations', () => {
                                   FROM sqlite_master
                                   WHERE type = 'table'
                                     AND name <> 'sqlite_sequence'`).all()
-      ).results
+      ).results.filter((table: any) => table.name !== '_cf_METADATA')
     ).toEqual([
       {
         name: 'migrations',

--- a/tests/unit/raw.test.ts
+++ b/tests/unit/raw.test.ts
@@ -1,77 +1,73 @@
 import { describe, expect, it } from 'vitest'
 import { QuerybuilderTest } from '../utils'
 
+import { FetchTypes } from '../../src/enums'
+
 describe('Raw Query Tests', () => {
   it('raw SELECT query with fetchType ALL', async () => {
-    const result = new QuerybuilderTest().raw('SELECT * FROM testTable WHERE name = ?1', ['testName']).getQueryAll()
+    const result = new QuerybuilderTest().raw({
+      query: 'SELECT * FROM testTable WHERE name = ?1',
+      args: ['testName'],
+      fetchType: FetchTypes.ALL,
+    })
     expect(result.query).toEqual('SELECT * FROM testTable WHERE name = ?1')
     expect(result.arguments).toEqual(['testName'])
-    expect(result.fetchType).toEqual('ALL')
+    expect(result.fetchType).toEqual(FetchTypes.ALL)
   })
 
   it('raw SELECT query with fetchType ONE', async () => {
-    const result = new QuerybuilderTest().raw('SELECT * FROM testTable WHERE id = ?1', [1]).getQueryOne()
+    const result = new QuerybuilderTest().raw({
+      query: 'SELECT * FROM testTable WHERE id = ?1',
+      args: [1],
+      fetchType: FetchTypes.ONE,
+    })
     expect(result.query).toEqual('SELECT * FROM testTable WHERE id = ?1')
     expect(result.arguments).toEqual([1])
-    expect(result.fetchType).toEqual('ONE')
+    expect(result.fetchType).toEqual(FetchTypes.ONE)
   })
 
   it('raw SELECT query without fetchType (default behavior)', async () => {
-    // Assuming default behavior for raw queries without explicit fetchType is to not set fetchType,
-    // or it might depend on the specific implementation (e.g., execute without returning results).
-    // For this example, let's assume it prepares the query and arguments but fetchType is undefined or a specific default.
-    const qb = new QuerybuilderTest()
-    const rawQuery = qb.raw('SELECT * FROM testTable')
-    // Depending on the library, `getQuery` might exist or you might need to call `execute` or similar
-    // For now, let's assume getQuery() would give us the prepared statement if that's how the library works
-    // or that we are testing the state of the builder before execution.
-    // This test might need adjustment based on actual library behavior for `raw()` without `getQueryAll/One()`.
-
-    // If raw() itself doesn't imply a fetch type until getQueryAll/One/Execute is called:
-    // We'll test what raw() returns directly if it's a builder instance we can inspect.
-    // Or, if raw() is meant to be chained with getQueryAll/One, this test might be redundant
-    // with the ones above, or it tests a different aspect like "execute"
-    const result = rawQuery.getQuery() // Assuming a generic getQuery() or similar for non-fetching ops
-
+    const result = new QuerybuilderTest().raw({ query: 'SELECT * FROM testTable' })
     expect(result.query).toEqual('SELECT * FROM testTable')
     expect(result.arguments).toBeUndefined()
-    // fetchType might be undefined or a specific default like 'NONE' or 'EXECUTE'
-    // Adjust based on actual library behavior. For now, expecting undefined.
     expect(result.fetchType).toBeUndefined()
   })
 
   it('raw INSERT query', async () => {
-    const result = new QuerybuilderTest()
-      .raw('INSERT INTO testTable (name, value) VALUES (?1, ?2)', ['newName', 100])
-      .getQuery()
+    const result = new QuerybuilderTest().raw({
+      query: 'INSERT INTO testTable (name, value) VALUES (?1, ?2)',
+      args: ['newName', 100],
+    })
     expect(result.query).toEqual('INSERT INTO testTable (name, value) VALUES (?1, ?2)')
     expect(result.arguments).toEqual(['newName', 100])
-    // INSERT operations typically don't have a fetchType like SELECT, or it might be 'EXECUTE' or undefined
-    expect(result.fetchType).toBeUndefined() // Or specific value like 'NONE' or 'EXECUTE'
+    expect(result.fetchType).toBeUndefined()
   })
 
   it('raw UPDATE query', async () => {
-    const result = new QuerybuilderTest()
-      .raw('UPDATE testTable SET name = ?1 WHERE id = ?2', ['updatedName', 2])
-      .getQuery()
+    const result = new QuerybuilderTest().raw({
+      query: 'UPDATE testTable SET name = ?1 WHERE id = ?2',
+      args: ['updatedName', 2],
+    })
     expect(result.query).toEqual('UPDATE testTable SET name = ?1 WHERE id = ?2')
     expect(result.arguments).toEqual(['updatedName', 2])
-    expect(result.fetchType).toBeUndefined() // Or specific value like 'NONE' or 'EXECUTE'
+    expect(result.fetchType).toBeUndefined()
   })
 
   it('raw DELETE query', async () => {
-    const result = new QuerybuilderTest().raw('DELETE FROM testTable WHERE id = ?1', [3]).getQuery()
+    const result = new QuerybuilderTest().raw({ query: 'DELETE FROM testTable WHERE id = ?1', args: [3] })
     expect(result.query).toEqual('DELETE FROM testTable WHERE id = ?1')
     expect(result.arguments).toEqual([3])
-    expect(result.fetchType).toBeUndefined() // Or specific value like 'NONE' or 'EXECUTE'
+    expect(result.fetchType).toBeUndefined()
   })
 
   it('raw query with positional parameters (?)', async () => {
-    const result = new QuerybuilderTest()
-      .raw('SELECT * FROM anotherTable WHERE col1 = ? AND col2 = ?', ['val1', 'val2'])
-      .getQueryAll()
+    const result = new QuerybuilderTest().raw({
+      query: 'SELECT * FROM anotherTable WHERE col1 = ? AND col2 = ?',
+      args: ['val1', 'val2'],
+      fetchType: FetchTypes.ALL,
+    })
     expect(result.query).toEqual('SELECT * FROM anotherTable WHERE col1 = ? AND col2 = ?')
     expect(result.arguments).toEqual(['val1', 'val2'])
-    expect(result.fetchType).toEqual('ALL')
+    expect(result.fetchType).toEqual(FetchTypes.ALL)
   })
 })

--- a/tests/unit/select.test.ts
+++ b/tests/unit/select.test.ts
@@ -868,15 +868,16 @@ describe('Select Builder', () => {
         join: {
           type: JoinTypes.CROSS,
           table: 'employees',
+          on: '1=1',
         },
       }),
       new QuerybuilderTest()
         .select('testTable')
         .fields('*')
-        .join({ type: JoinTypes.CROSS, table: 'employees' })
+        .join({ type: JoinTypes.CROSS, table: 'employees', on: '1=1' })
         .getQueryAll(),
     ]) {
-      expect(result.query).toEqual('SELECT * FROM testTable CROSS JOIN employees')
+      expect(result.query).toEqual('SELECT * FROM testTable CROSS JOIN employees ON 1=1')
       expect(result.arguments).toBeUndefined()
       expect(result.fetchType).toEqual('ALL')
     }
@@ -890,6 +891,7 @@ describe('Select Builder', () => {
         join: {
           type: JoinTypes.CROSS,
           table: 'employees',
+          on: '1=1',
         },
         where: {
           conditions: 'field = ?',
@@ -899,11 +901,11 @@ describe('Select Builder', () => {
       new QuerybuilderTest()
         .select('testTable')
         .fields('*')
-        .join({ type: JoinTypes.CROSS, table: 'employees' })
+        .join({ type: JoinTypes.CROSS, table: 'employees', on: '1=1' })
         .where('field = ?', 'test')
         .getQueryAll(),
     ]) {
-      expect(result.query).toEqual('SELECT * FROM testTable CROSS JOIN employees WHERE field = ?')
+      expect(result.query).toEqual('SELECT * FROM testTable CROSS JOIN employees ON 1=1 WHERE field = ?')
       expect(result.arguments).toEqual(['test'])
       expect(result.fetchType).toEqual('ALL')
     }
@@ -917,15 +919,16 @@ describe('Select Builder', () => {
         join: {
           type: JoinTypes.CROSS,
           table: 'employees',
+          on: '1=1',
         },
       }),
       new QuerybuilderTest()
         .select('testTable')
         .fields(['id', 'name'])
-        .join({ type: JoinTypes.CROSS, table: 'employees' })
+        .join({ type: JoinTypes.CROSS, table: 'employees', on: '1=1' })
         .getQueryAll(),
     ]) {
-      expect(result.query).toEqual('SELECT id, name FROM testTable CROSS JOIN employees')
+      expect(result.query).toEqual('SELECT id, name FROM testTable CROSS JOIN employees ON 1=1')
       expect(result.arguments).toBeUndefined()
       expect(result.fetchType).toEqual('ALL')
     }


### PR DESCRIPTION
This commit fixes two sets of failing tests:

1. Cross join tests:
    - The `join` function for cross joins was missing the `on` property.
    - Added `on: '1=1'` to the join object in `tests/unit/select.test.ts` as per documentation.
    - Updated assertions to match the corrected SQL query.

2. Raw query tests:
    - The `raw` function was being called with incorrect parameters.
    - Modified calls in `tests/unit/raw.test.ts` to pass an object with `query`, `args`, and `fetchType` properties, as per documentation.
    - Removed chained `getQueryX` calls and used `FetchTypes` enum for clarity.

Additionally, I fixed an issue in `tests/integration/migrations-d1.test.ts` by filtering out the `_cf_METADATA` table from assertions.

All tests now pass after these changes.