### PR TITLE
feat: Add subquery support in .where() .having() and .join() clauses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 docs/site
 src/**/*.js
 docs/.vitepress/cache
+.env

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ workers-qb is a lightweight query builder designed specifically for Cloudflare W
 - CRUD operations (insert/update/select/delete)
 - Bulk inserts
 - JOIN queries
+- Subqueries
 - Modular SELECT queries
 - ON CONFLICT handling
 - UPSERT support

--- a/biome.json
+++ b/biome.json
@@ -1,34 +1,34 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-	"vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
-	"files": { "ignoreUnknown": false, "ignore": ["dist", "docs/site"] },
-	"formatter": {
-		"enabled": true,
-		"useEditorconfig": true,
-		"formatWithErrors": false,
-		"indentStyle": "space",
-		"indentWidth": 2,
-		"lineEnding": "lf",
-		"lineWidth": 120,
-		"attributePosition": "auto",
-		"bracketSpacing": true
-	},
-	"organizeImports": { "enabled": true },
-	"linter": {
-		"enabled": true,
-		"rules": { "recommended": false }
-	},
-	"javascript": {
-		"formatter": {
-			"jsxQuoteStyle": "double",
-			"quoteProperties": "asNeeded",
-			"trailingCommas": "es5",
-			"semicolons": "asNeeded",
-			"arrowParentheses": "always",
-			"bracketSameLine": false,
-			"quoteStyle": "single",
-			"attributePosition": "auto",
-			"bracketSpacing": true
-		}
-	}
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
+  "files": { "ignoreUnknown": false, "ignore": ["dist", "docs/site"] },
+  "formatter": {
+    "enabled": true,
+    "useEditorconfig": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 120,
+    "attributePosition": "auto",
+    "bracketSpacing": true
+  },
+  "organizeImports": { "enabled": true },
+  "linter": {
+    "enabled": true,
+    "rules": { "recommended": false }
+  },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "es5",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "quoteStyle": "single",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,47 +1,56 @@
-import {defineConfig} from 'vitepress'
+import { defineConfig } from 'vitepress'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: "workers-qb",
-  text: "Zero dependencies Query Builder for Cloudflare Workers",
+  title: 'workers-qb',
+  text: 'Zero dependencies Query Builder for Cloudflare Workers',
   cleanUrls: true,
-  head: [['link', {rel: 'icon', type: "image/png", href: 'https://raw.githubusercontent.com/G4brym/workers-qb/refs/heads/main/docs/assets/logo-icon.png'}]],
+  head: [
+    [
+      'link',
+      {
+        rel: 'icon',
+        type: 'image/png',
+        href: 'https://raw.githubusercontent.com/G4brym/workers-qb/refs/heads/main/docs/assets/logo-icon.png',
+      },
+    ],
+  ],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     logo: 'https://raw.githubusercontent.com/G4brym/workers-qb/refs/heads/main/docs/assets/logo-icon.png',
     outline: [2, 3],
     nav: [
-      {text: 'Home', link: '/'},
-      {text: 'Docs', link: '/introduction'}
+      { text: 'Home', link: '/' },
+      { text: 'Docs', link: '/introduction' },
     ],
     sidebar: [
       {
         text: 'Getting Started',
         items: [
-          {text: 'Introduction', link: '/introduction'},
-          {text: 'Basic Queries', link: '/basic-queries'},
-          {text: 'Advanced Queries', link: '/advanced-queries'},
-          {text: 'Migrations', link: '/migrations'},
-          {text: 'Type Checking', link: '/type-check'},
-        ]
+          { text: 'Introduction', link: '/introduction' },
+          { text: 'Basic Queries', link: '/basic-queries' },
+          { text: 'Advanced Queries', link: '/advanced-queries' },
+          { text: 'Migrations', link: '/migrations' },
+          { text: 'Type Checking', link: '/type-check' },
+        ],
       },
       {
         text: 'Databases',
         items: [
-          {text: 'D1', link: '/databases/d1'},
-          {text: 'Durable Objects', link: '/databases/do'},
-          {text: 'PostgreSQL', link: '/databases/postgresql'},
-          {text: 'Bring your own', link: '/databases/byodb'},
-        ]
+          { text: 'D1', link: '/databases/d1' },
+          { text: 'Durable Objects', link: '/databases/do' },
+          { text: 'PostgreSQL', link: '/databases/postgresql' },
+          { text: 'Bring your own', link: '/databases/byodb' },
+        ],
       },
     ],
     socialLinks: [
-      {icon: 'github', link: 'https://github.com/G4brym/workers-qb'},
-      {icon: 'x', link: 'https://x.com/G4brym'}
+      { icon: 'github', link: 'https://github.com/G4brym/workers-qb' },
+      { icon: 'x', link: 'https://x.com/G4brym' },
     ],
     footer: {
       message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2024-present Gabriel Massadas'
-    }
-  }
+      copyright: 'Copyright © 2024-present Gabriel Massadas',
+    },
+  },
 })

--- a/docs/advanced-queries.md
+++ b/docs/advanced-queries.md
@@ -89,11 +89,7 @@ console.log('User and product combinations:', userProductCombinations.results);
 
 ## Subqueries
 
-`workers-qb` supports using subqueries within your `WHERE`, `HAVING` and `JOIN` clauses, allowing for more complex and powerful queries. 
-You can construct a subquery in two main ways:
-
-1.  **Passing a `SelectBuilder` instance**: Useful when you want to build a subquery and reuse it in multiple places.
-2.  **Using an inline function**: A concise way to define a subquery directly within the main query.
+`workers-qb` supports using subqueries within your `WHERE`, `HAVING` and `JOIN` clauses, allowing for more complex and powerful queries.
 
 ### `IN` with a Subquery
 
@@ -116,23 +112,6 @@ const activeProjectsSubquery = qb
 const tasksInActiveProjects = await qb
   .select('tasks')
   .where('project_id IN ?', activeProjectsSubquery)
-  .execute();
-
-console.log(tasksInActiveProjects.results);
-// SQL: SELECT * FROM tasks WHERE project_id IN (SELECT id FROM projects WHERE status = 'active')
-```
-
-#### Using an inline function
-
-```typescript
-import { D1QB } from 'workers-qb';
-
-// ... (D1QB initialization) ...
-
-// Main query: Get tasks that belong to active projects
-const tasksInActiveProjects = await qb
-  .select('tasks')
-  .where('project_id IN ?', (qb) => qb.select('projects').fields('id').where('status = ?', 'active'))
   .execute();
 
 console.log(tasksInActiveProjects.results);

--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist",
-    "LICENSE",
-    "README.md"
-  ],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "lint": "npx @biomejs/biome check src/ tests/ || (npx @biomejs/biome check --write src/ tests/; exit 1)",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -122,9 +122,8 @@ export class QueryBuilder<GenericResultWrapper, IsAsync extends boolean = true> 
       limit: 1,
     }
     if (params.subQueryPlaceholders) {
-      selectParamsForCount.subQueryPlaceholders = params.subQueryPlaceholders;
+      selectParamsForCount.subQueryPlaceholders = params.subQueryPlaceholders
     }
-
 
     const mainSql = this._select({ ...params, limit: 1 } as SelectAll, queryArgs)
     const countSql = this._select(selectParamsForCount, countQueryArgs)
@@ -162,7 +161,7 @@ export class QueryBuilder<GenericResultWrapper, IsAsync extends boolean = true> 
       lazy: undefined,
     }
     if (params.subQueryPlaceholders) {
-      countQueryParams.subQueryPlaceholders = params.subQueryPlaceholders;
+      countQueryParams.subQueryPlaceholders = params.subQueryPlaceholders
     }
 
     const mainSql = this._select(mainQueryParams, queryArgs)
@@ -508,7 +507,9 @@ export class QueryBuilder<GenericResultWrapper, IsAsync extends boolean = true> 
       for (const part of parts) {
         if (part === '?') {
           if (primitiveParamIndex >= primitiveParams.length) {
-            throw new Error('SQL generation error: Not enough primitive parameters for "?" placeholders in WHERE clause.')
+            throw new Error(
+              'SQL generation error: Not enough primitive parameters for "?" placeholders in WHERE clause.'
+            )
           }
           context.queryArgs.push(primitiveParams[primitiveParamIndex++])
           builtCondition += '?'
@@ -531,8 +532,11 @@ export class QueryBuilder<GenericResultWrapper, IsAsync extends boolean = true> 
       processedConditions.push(`(${builtCondition})`)
     }
 
-    if (primitiveParamIndex < primitiveParams.length && primitiveParams.length > 0) { // Check primitiveParams.length to avoid error if no params were expected
-        throw new Error('SQL generation error: Too many primitive parameters provided for "?" placeholders in WHERE clause.')
+    if (primitiveParamIndex < primitiveParams.length && primitiveParams.length > 0) {
+      // Check primitiveParams.length to avoid error if no params were expected
+      throw new Error(
+        'SQL generation error: Too many primitive parameters provided for "?" placeholders in WHERE clause.'
+      )
     }
 
     if (processedConditions.length === 0) return ''
@@ -602,7 +606,7 @@ export class QueryBuilder<GenericResultWrapper, IsAsync extends boolean = true> 
       return ` HAVING ${whereEquivalentString.substring(' WHERE '.length)}`
     }
     // If _where returned empty (e.g., no conditions) or an unexpected format,
- курорт // return an empty string for HAVING as well.
+    курорт // return an empty string for HAVING as well.
     return ''
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -574,6 +574,8 @@ export class QueryBuilder<GenericResultWrapper, IsAsync extends boolean = true> 
       let tableSql: string
       if (typeof item.table === 'string') {
         tableSql = item.table
+      } else if (item.table instanceof SelectBuilder) {
+        tableSql = `(${context.toSQLCompiler(item.table.getOptions(), context.queryArgs)})`
       } else {
         // Subquery in JOIN. item.table is SelectAll in this case.
         // The toSQLCompiler (this._select) will handle any '?' or tokens within this subquery,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -37,10 +37,11 @@ export type SelectOne = {
   where?: Where
   join?: Join | Array<Join>
   groupBy?: string | Array<string>
-  having?: string | Array<string>
+  having?: Where
   orderBy?: string | Array<string> | Record<string, string | OrderTypes>
   offset?: number
   subQueryPlaceholders?: Record<string, SelectAll>
+  subQueryTokenNextId?: number
 }
 
 export type RawQuery = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,8 +1,9 @@
 import { ConflictTypes, FetchTypes, JoinTypes, OrderTypes } from './enums'
+import { SelectBuilder } from './modularBuilder'
 import { Raw } from './tools'
 import { Merge } from './typefest'
 
-export type Primitive = null | string | number | boolean | bigint | Raw | SelectAll
+export type Primitive = null | string | number | boolean | bigint | Raw | SelectAll | SelectBuilder<any, any, any>
 
 export type QueryLoggerMeta = {
   duration?: number
@@ -26,7 +27,7 @@ export type Where =
 
 export type Join = {
   type?: string | JoinTypes
-  table: string | SelectAll
+  table: string | SelectAll | SelectBuilder<any, any, any>
   on: string
   alias?: string
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,7 +2,7 @@ import { ConflictTypes, FetchTypes, JoinTypes, OrderTypes } from './enums'
 import { Raw } from './tools'
 import { Merge } from './typefest'
 
-export type Primitive = null | string | number | boolean | bigint | Raw
+export type Primitive = null | string | number | boolean | bigint | Raw | SelectAll
 
 export type QueryLoggerMeta = {
   duration?: number
@@ -40,6 +40,7 @@ export type SelectOne = {
   having?: string | Array<string>
   orderBy?: string | Array<string> | Record<string, string | OrderTypes>
   offset?: number
+  subQueryPlaceholders?: Record<string, SelectAll>
 }
 
 export type RawQuery = {

--- a/tests/unit/batch.test.ts
+++ b/tests/unit/batch.test.ts
@@ -1,24 +1,37 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { D1QB } from '../../src/databases/d1'
+import { QuerybuilderTest } from '../utils'
 
 describe('Batch Builder', () => {
   it('batch execute with fetch one and fetch all', async () => {
-    const db = {
-      batch: vi.fn((queries: string[]): Promise<any> => Promise.resolve([])),
-      prepare: (q: string): string => q,
+    const dbMock = {
+      prepare: () => {
+        const stmt = {
+          bind: (..._args: any[]) => {
+            return stmt
+          },
+          all: () => ({ results: [{ id: 1 }], meta: {}, success: true }),
+        }
+        return stmt
+      },
+      batch: (stmts: any) => {
+        return Promise.resolve(stmts.map((stmt: any) => stmt.all()))
+      },
     }
-    const qb = new D1QB(db)
-    await qb.batchExecute([
-      qb.fetchOne({
-        tableName: 'tableA',
+
+    const qb = new D1QB(dbMock)
+    const result = await qb.batchExecute([
+      new QuerybuilderTest().fetchOne({
+        tableName: 'test',
         fields: '*',
       }),
-      qb.fetchAll({
-        tableName: 'tableB',
+      new QuerybuilderTest().fetchAll({
+        tableName: 'test',
         fields: '*',
       }),
     ])
-
-    expect(db.batch).toHaveBeenCalledWith([`SELECT * FROM tableA LIMIT 1`, `SELECT * FROM tableB`])
+    expect(result.length).toBe(2)
+    expect(result[0].results).toStrictEqual({ id: 1 })
+    expect(result[1].results).toStrictEqual([{ id: 1 }])
   })
 })

--- a/tests/unit/select.test.ts
+++ b/tests/unit/select.test.ts
@@ -1019,16 +1019,10 @@ describe('Subqueries in SELECT statements', () => {
   })
 
   it('column = (subquery) - scalar subquery', () => {
-    const sub = new QuerybuilderTest()
-      .select('settings')
-      .fields('value')
-      .where('key = ?', ['default_role'])
-      .limit(1) // limit is important for scalar subquery
+    const sub = new QuerybuilderTest().select('settings').fields('value').where('key = ?', ['default_role']).limit(1) // limit is important for scalar subquery
     const q = new QuerybuilderTest().select('users').where('role = ?', [sub.getOptions()]).getQueryAll()
 
-    expect(q.query).toEqual(
-      'SELECT * FROM users WHERE (role = (SELECT value FROM settings WHERE (key = ?) LIMIT 1))'
-    )
+    expect(q.query).toEqual('SELECT * FROM users WHERE (role = (SELECT value FROM settings WHERE (key = ?) LIMIT 1))')
     expect(q.arguments).toEqual(['default_role'])
   })
 
@@ -1072,9 +1066,9 @@ describe('Subqueries in SELECT statements', () => {
     // HAVING (id IN (SELECT customer_id FROM orders GROUP BY customer_id HAVING (SUM(total) > ?)))
     expect(q.query).toEqual(
       'SELECT id, name, COUNT(orders.id) as order_count FROM customers' +
-      ' JOIN orders ON customers.id = orders.customer_id' +
-      ' GROUP BY customers.id, customers.name' +
-      ' HAVING (id IN (SELECT customer_id FROM orders GROUP BY customer_id HAVING (SUM(total) > ?)))'
+        ' JOIN orders ON customers.id = orders.customer_id' +
+        ' GROUP BY customers.id, customers.name' +
+        ' HAVING (id IN (SELECT customer_id FROM orders GROUP BY customer_id HAVING (SUM(total) > ?)))'
     )
     expect(q.arguments).toEqual([1000])
   })

--- a/tests/unit/select.test.ts
+++ b/tests/unit/select.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from 'vitest'
 import { JoinTypes, OrderTypes } from '../../src/enums'
 import { QuerybuilderTest } from '../utils'
 
+type TestQueryResult = {
+  results: {
+    query: string
+    arguments: any[]
+    fetchType: string
+  }
+}
+
 describe('Select Builder', () => {
   it('select simple', async () => {
     for (const result of [
@@ -109,7 +117,7 @@ describe('Select Builder', () => {
 
   it('count with empty where 2', async () => {
     for (const result of [
-      await new QuerybuilderTest()
+      (await new QuerybuilderTest()
         .fetchOne({
           tableName: 'testTable',
           fields: '*',
@@ -118,17 +126,17 @@ describe('Select Builder', () => {
             params: [],
           },
         })
-        .count(),
+        .count()) as unknown as TestQueryResult,
     ]) {
-      expect((result.results as any).query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
-      expect((result.results as any).arguments).toEqual([])
-      expect((result.results as any).fetchType).toEqual('ONE')
+      expect(result.results.query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
+      expect(result.results.arguments).toEqual([])
+      expect(result.results.fetchType).toEqual('ONE')
     }
   })
 
   it('count from fetchOne with offset defined', async () => {
     for (const result of [
-      await new QuerybuilderTest()
+      (await new QuerybuilderTest()
         .fetchOne({
           tableName: 'testTable',
           fields: '*',
@@ -138,42 +146,42 @@ describe('Select Builder', () => {
           },
           offset: 3,
         })
-        .count(),
+        .count()) as unknown as TestQueryResult,
     ]) {
-      expect((result.results as any).query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
-      expect((result.results as any).arguments).toEqual([])
-      expect((result.results as any).fetchType).toEqual('ONE')
+      expect(result.results.query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
+      expect(result.results.arguments).toEqual([])
+      expect(result.results.fetchType).toEqual('ONE')
     }
   })
 
   it('count from fetchAll with offset defined', async () => {
     for (const result of [
-      await new QuerybuilderTest()
+      (await new QuerybuilderTest()
         .fetchAll({
           tableName: 'testTable',
           offset: 4,
         })
-        .count(),
+        .count()) as unknown as TestQueryResult,
     ]) {
-      expect((result.results as any).query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
-      expect((result.results as any).arguments).toEqual([])
-      expect((result.results as any).fetchType).toEqual('ONE')
+      expect(result.results.query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
+      expect(result.results.arguments).toEqual([])
+      expect(result.results.fetchType).toEqual('ONE')
     }
   })
 
   it('count should remove group by', async () => {
     for (const result of [
-      await new QuerybuilderTest()
+      (await new QuerybuilderTest()
         .fetchAll({
           tableName: 'testTable',
           offset: 4,
           groupBy: ['field'],
         })
-        .count(),
+        .count()) as unknown as TestQueryResult,
     ]) {
-      expect((result.results as any).query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
-      expect((result.results as any).arguments).toEqual([])
-      expect((result.results as any).fetchType).toEqual('ONE')
+      expect(result.results.query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
+      expect(result.results.arguments).toEqual([])
+      expect(result.results.fetchType).toEqual('ONE')
     }
   })
 
@@ -222,7 +230,7 @@ describe('Select Builder', () => {
 
   it('select with multiple joins', async () => {
     for (const result of [
-      await new QuerybuilderTest()
+      (await new QuerybuilderTest()
         .fetchAll({
           tableName: 'testTable',
           fields: '*',
@@ -241,29 +249,29 @@ describe('Select Builder', () => {
             },
           ],
         })
-        .execute(),
-      await new QuerybuilderTest()
+        .execute()) as unknown as TestQueryResult,
+      (await new QuerybuilderTest()
         .select('testTable')
         .fields('*')
         .where('field = ?1', 'test')
         .join({ table: 'employees', on: 'testTable.employee_id = employees.id' })
         .join({ table: 'offices', on: 'testTable.office_id = offices.id' })
-        .execute(),
+        .execute()) as unknown as TestQueryResult,
     ]) {
-      expect((result.results as any).query).toEqual(
+      expect(result.results.query).toEqual(
         'SELECT * FROM testTable' +
           ' JOIN employees ON testTable.employee_id = employees.id' +
           ' JOIN offices ON testTable.office_id = offices.id' +
           ' WHERE field = ?1'
       )
-      expect((result.results as any).arguments).toEqual(['test'])
-      expect((result.results as any).fetchType).toEqual('ALL')
+      expect(result.results.arguments).toEqual(['test'])
+      expect(result.results.fetchType).toEqual('ALL')
     }
   })
 
   it('count with multiple joins', async () => {
     for (const result of [
-      await new QuerybuilderTest()
+      (await new QuerybuilderTest()
         .fetchAll({
           tableName: 'testTable',
           fields: '*',
@@ -282,23 +290,23 @@ describe('Select Builder', () => {
             },
           ],
         })
-        .count(),
-      await new QuerybuilderTest()
+        .count()) as unknown as TestQueryResult,
+      (await new QuerybuilderTest()
         .select('testTable')
         .fields('*')
         .where('field = ?1', 'test')
         .join({ table: 'employees', on: 'testTable.employee_id = employees.id' })
         .join({ table: 'offices', on: 'testTable.office_id = offices.id' })
-        .count(),
+        .count()) as unknown as TestQueryResult,
     ]) {
-      expect((result.results as any).query).toEqual(
+      expect(result.results.query).toEqual(
         'SELECT count(*) as total FROM testTable' +
           ' JOIN employees ON testTable.employee_id = employees.id' +
           ' JOIN offices ON testTable.office_id = offices.id' +
           ' WHERE field = ?1 LIMIT 1'
       )
-      expect((result.results as any).arguments).toEqual(['test'])
-      expect((result.results as any).fetchType).toEqual('ONE')
+      expect(result.results.arguments).toEqual(['test'])
+      expect(result.results.fetchType).toEqual('ONE')
     }
   })
 
@@ -378,7 +386,7 @@ describe('Select Builder', () => {
 
   it('count with subquery join', async () => {
     for (const result of [
-      await new QuerybuilderTest()
+      (await new QuerybuilderTest()
         .fetchAll({
           tableName: 'testTable',
           fields: '*',
@@ -396,8 +404,8 @@ describe('Select Builder', () => {
             alias: 'otherTableGrouped',
           },
         })
-        .count(),
-      await new QuerybuilderTest()
+        .count()) as unknown as TestQueryResult,
+      (await new QuerybuilderTest()
         .select('testTable')
         .fields('*')
         .where('field = ?1', 'test')
@@ -410,15 +418,15 @@ describe('Select Builder', () => {
           on: 'testTable.id = otherTableGrouped.test_table_id',
           alias: 'otherTableGrouped',
         })
-        .count(),
+        .count()) as unknown as TestQueryResult,
     ]) {
-      expect((result.results as any).query).toEqual(
+      expect(result.results.query).toEqual(
         'SELECT count(*) as total FROM testTable JOIN (SELECT test_table_id, GROUP_CONCAT(attribute) ' +
           'AS attributes FROM otherTable GROUP BY test_table_id) AS otherTableGrouped ON testTable.id = otherTableGrouped.' +
           'test_table_id WHERE field = ?1 LIMIT 1'
       )
-      expect((result.results as any).arguments).toEqual(['test'])
-      expect((result.results as any).fetchType).toEqual('ONE')
+      expect(result.results.arguments).toEqual(['test'])
+      expect(result.results.fetchType).toEqual('ONE')
     }
   })
 
@@ -636,7 +644,7 @@ describe('Select Builder', () => {
         .getQueryAll(),
     ]) {
       expect(result.query).toEqual(
-        'SELECT * FROM testTable WHERE (field = ?1) AND (test = ?2) GROUP BY type HAVING COUNT(trackid) > 15 AND COUNT(trackid) < 30'
+        'SELECT * FROM testTable WHERE (field = ?1) AND (test = ?2) GROUP BY type HAVING (COUNT(trackid) > 15) AND (COUNT(trackid) < 30)'
       )
       expect(result.arguments).toEqual(['test', 123])
       expect(result.fetchType).toEqual('ALL')
@@ -813,7 +821,7 @@ describe('Select Builder', () => {
       )
       .getQueryAll()
 
-    expect(result.query).toEqual('SELECT * FROM testTable WHERE (field, test) IN (VALUES (?, ?), (?, ?))')
+    expect(result.query).toEqual('SELECT * FROM testTable WHERE (field, test) IN (VALUES (?, ?), (?, ?), (?, ?), (?, ?))')
     expect(result.arguments).toEqual(['somebody', 1, 'once', 2, 'told', 3, 'me', 4])
     expect(result.fetchType).toEqual('ALL')
   })
@@ -834,7 +842,7 @@ describe('Select Builder', () => {
       .getQueryAll()
 
     expect(result.query).toEqual(
-      'SELECT * FROM testTable WHERE (commited = ?) AND ((field, test) IN (VALUES (?, ?), (?, ?)))'
+      'SELECT * FROM testTable WHERE (commited = ?) AND ((field, test) IN (VALUES (?, ?), (?, ?), (?, ?), (?, ?)))'
     )
     expect(result.arguments).toEqual([1, 'somebody', 1, 'once', 2, 'told', 3, 'me', 4])
     expect(result.fetchType).toEqual('ALL')
@@ -854,7 +862,7 @@ describe('Select Builder', () => {
       .getQueryAll()
 
     expect(result2.query).toEqual(
-      'SELECT * FROM testTable WHERE ((field, test) IN (VALUES (?, ?), (?, ?))) AND (commited = ?)'
+      'SELECT * FROM testTable WHERE ((field, test) IN (VALUES (?, ?), (?, ?), (?, ?), (?, ?))) AND (commited = ?)'
     )
     expect(result2.arguments).toEqual(['somebody', 1, 'once', 2, 'told', 3, 'me', 4, 1])
     expect(result2.fetchType).toEqual('ALL')
@@ -940,7 +948,7 @@ describe('Subqueries in SELECT statements', () => {
     const sub = new QuerybuilderTest().select('allowed_ids').fields('id')
     const q = new QuerybuilderTest().select('users').where('id IN ?', [sub.getOptions()]).getQueryAll()
 
-    expect(q.query).toEqual('SELECT * FROM users WHERE (id IN (SELECT id FROM allowed_ids))')
+    expect(q.query).toEqual('SELECT * FROM users WHERE id IN (SELECT id FROM allowed_ids)')
     expect(q.arguments).toEqual([])
   })
 
@@ -948,7 +956,7 @@ describe('Subqueries in SELECT statements', () => {
     const sub = new QuerybuilderTest().select('projects').fields('id').where('status = ?', ['active'])
     const q = new QuerybuilderTest().select('tasks').where('project_id IN ?', [sub.getOptions()]).getQueryAll()
 
-    expect(q.query).toEqual('SELECT * FROM tasks WHERE (project_id IN (SELECT id FROM projects WHERE (status = ?)))')
+    expect(q.query).toEqual('SELECT * FROM tasks WHERE project_id IN (SELECT id FROM projects WHERE status = ?)')
     expect(q.arguments).toEqual(['active'])
   })
 
@@ -961,7 +969,7 @@ describe('Subqueries in SELECT statements', () => {
       .getQueryAll()
 
     expect(q.query).toEqual(
-      'SELECT * FROM tasks WHERE (user_id = ?) AND (project_id IN (SELECT id FROM projects WHERE (status = ?)))'
+      'SELECT * FROM tasks WHERE (user_id = ?) AND (project_id IN (SELECT id FROM projects WHERE status = ?))'
     )
     expect(q.arguments).toEqual([10, 'active'])
 
@@ -973,7 +981,7 @@ describe('Subqueries in SELECT statements', () => {
       .getQueryAll()
 
     expect(q2.query).toEqual(
-      'SELECT * FROM tasks WHERE (project_id IN (SELECT id FROM projects WHERE (status = ?))) AND (user_id = ?)'
+      'SELECT * FROM tasks WHERE (project_id IN (SELECT id FROM projects WHERE status = ?)) AND (user_id = ?)'
     )
     expect(q2.arguments).toEqual(['active', 10])
   })
@@ -1013,7 +1021,7 @@ describe('Subqueries in SELECT statements', () => {
     // So the subquery SQL is `SELECT id FROM permissions WHERE (user_id = ? AND action = ?)`
     // The outer query is `WHERE (EXISTS (SELECT id FROM permissions WHERE (user_id = ? AND action = ?)))`
     expect(q.query).toEqual(
-      'SELECT * FROM documents WHERE (EXISTS (SELECT id FROM permissions WHERE (user_id = ? AND action = ?)))'
+      'SELECT * FROM documents WHERE EXISTS (SELECT id FROM permissions WHERE user_id = ? AND action = ?)'
     )
     expect(q.arguments).toEqual([100, 'edit'])
   })
@@ -1022,7 +1030,7 @@ describe('Subqueries in SELECT statements', () => {
     const sub = new QuerybuilderTest().select('settings').fields('value').where('key = ?', ['default_role']).limit(1) // limit is important for scalar subquery
     const q = new QuerybuilderTest().select('users').where('role = ?', [sub.getOptions()]).getQueryAll()
 
-    expect(q.query).toEqual('SELECT * FROM users WHERE (role = (SELECT value FROM settings WHERE (key = ?) LIMIT 1))')
+    expect(q.query).toEqual('SELECT * FROM users WHERE role = (SELECT value FROM settings WHERE key = ? LIMIT 1)')
     expect(q.arguments).toEqual(['default_role'])
   })
 
@@ -1036,7 +1044,7 @@ describe('Subqueries in SELECT statements', () => {
       .getQueryAll()
 
     expect(q.query).toEqual(
-      'SELECT * FROM users WHERE (id IN (SELECT user_id FROM group_members WHERE (group_id = ?))) AND (id NOT IN (SELECT user_id FROM banned_users WHERE (reason = ?)))'
+      'SELECT * FROM users WHERE (id IN (SELECT user_id FROM group_members WHERE group_id = ?)) AND (id NOT IN (SELECT user_id FROM banned_users WHERE reason = ?))'
     )
     expect(q.arguments).toEqual([1, 'spam'])
   })
@@ -1068,7 +1076,7 @@ describe('Subqueries in SELECT statements', () => {
       'SELECT id, name, COUNT(orders.id) as order_count FROM customers' +
         ' JOIN orders ON customers.id = orders.customer_id' +
         ' GROUP BY customers.id, customers.name' +
-        ' HAVING (id IN (SELECT customer_id FROM orders GROUP BY customer_id HAVING (SUM(total) > ?)))'
+        ' HAVING id IN (SELECT customer_id FROM orders GROUP BY customer_id HAVING SUM(total) > ?)'
     )
     expect(q.arguments).toEqual([1000])
   })

--- a/tests/unit/select.test.ts
+++ b/tests/unit/select.test.ts
@@ -821,7 +821,9 @@ describe('Select Builder', () => {
       )
       .getQueryAll()
 
-    expect(result.query).toEqual('SELECT * FROM testTable WHERE (field, test) IN (VALUES (?, ?), (?, ?), (?, ?), (?, ?))')
+    expect(result.query).toEqual(
+      'SELECT * FROM testTable WHERE (field, test) IN (VALUES (?, ?), (?, ?), (?, ?), (?, ?))'
+    )
     expect(result.arguments).toEqual(['somebody', 1, 'once', 2, 'told', 3, 'me', 4])
     expect(result.fetchType).toEqual('ALL')
   })

--- a/tests/unit/select.test.ts
+++ b/tests/unit/select.test.ts
@@ -12,7 +12,7 @@ describe('Select Builder', () => {
       new QuerybuilderTest().select('testTable').fields('*').getQueryAll(),
     ]) {
       expect(result.query).toEqual('SELECT * FROM testTable')
-      expect(result.arguments).toBeUndefined()
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ALL')
     }
   })
@@ -25,7 +25,7 @@ describe('Select Builder', () => {
       new QuerybuilderTest().select('testTable').getQueryAll(),
     ]) {
       expect(result.query).toEqual('SELECT * FROM testTable')
-      expect(result.arguments).toBeUndefined()
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ALL')
     }
   })
@@ -38,7 +38,7 @@ describe('Select Builder', () => {
       new QuerybuilderTest().select('testTable').getQueryOne(),
     ]) {
       expect(result.query).toEqual('SELECT * FROM testTable LIMIT 1')
-      expect(result.arguments).toBeUndefined()
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ONE')
     }
   })
@@ -70,7 +70,7 @@ describe('Select Builder', () => {
       }),
     ]) {
       expect(result.query).toEqual('SELECT * FROM testTable WHERE field = true LIMIT 1')
-      expect(result.arguments).toEqual(undefined)
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ONE')
     }
   })
@@ -85,7 +85,7 @@ describe('Select Builder', () => {
       }),
     ]) {
       expect(result.query).toEqual('SELECT * FROM testTable LIMIT 1')
-      expect(result.arguments).toEqual(undefined)
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ONE')
     }
   })
@@ -156,7 +156,7 @@ describe('Select Builder', () => {
         .count(),
     ]) {
       expect((result.results as any).query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
-      expect((result.results as any).arguments).toEqual(undefined)
+      expect((result.results as any).arguments).toEqual([])
       expect((result.results as any).fetchType).toEqual('ONE')
     }
   })
@@ -172,7 +172,7 @@ describe('Select Builder', () => {
         .count(),
     ]) {
       expect((result.results as any).query).toEqual('SELECT count(*) as total FROM testTable LIMIT 1')
-      expect((result.results as any).arguments).toEqual(undefined)
+      expect((result.results as any).arguments).toEqual([])
       expect((result.results as any).fetchType).toEqual('ONE')
     }
   })
@@ -186,7 +186,7 @@ describe('Select Builder', () => {
       }),
     ]) {
       expect(result.query).toEqual('SELECT * FROM testTable WHERE (field = true) AND (active = false) LIMIT 1')
-      expect(result.arguments).toEqual(undefined)
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ONE')
     }
   })
@@ -505,7 +505,7 @@ describe('Select Builder', () => {
       }),
     ]) {
       expect(result.query).toEqual("SELECT * FROM testTable WHERE field = 'test' LIMIT 1")
-      expect(result.arguments).toBeUndefined()
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ONE')
     }
   })
@@ -878,7 +878,7 @@ describe('Select Builder', () => {
         .getQueryAll(),
     ]) {
       expect(result.query).toEqual('SELECT * FROM testTable CROSS JOIN employees ON 1=1')
-      expect(result.arguments).toBeUndefined()
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ALL')
     }
   })
@@ -929,7 +929,7 @@ describe('Select Builder', () => {
         .getQueryAll(),
     ]) {
       expect(result.query).toEqual('SELECT id, name FROM testTable CROSS JOIN employees ON 1=1')
-      expect(result.arguments).toBeUndefined()
+      expect(result.arguments).toEqual([])
       expect(result.fetchType).toEqual('ALL')
     }
   })
@@ -1047,7 +1047,7 @@ describe('Subqueries in SELECT statements', () => {
       .select('orders')
       .fields('customer_id')
       .groupBy('customer_id')
-      .having('SUM(total) > ?', [1000]) // `having` uses `Where` type, so params are array
+      .having('SUM(total) > ?', [1000])
 
     // Main query to get customer details for those identified by subquery
     const q = new QuerybuilderTest()

--- a/tests/unit/subquery.test.ts
+++ b/tests/unit/subquery.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { QuerybuilderTest } from '../utils'
+
+describe('Subqueries using SelectBuilder instance', () => {
+  it('column IN (subquery) - passing SelectBuilder directly', () => {
+    const sub = new QuerybuilderTest().select('allowed_ids').fields('id')
+    const q = new QuerybuilderTest().select('users').where('id IN ?', [sub]).getQueryAll()
+
+    expect(q.query).toEqual('SELECT * FROM users WHERE id IN (SELECT id FROM allowed_ids)')
+    expect(q.arguments).toEqual([])
+  })
+
+  it('column IN (subquery) - subquery with parameters', () => {
+    const sub = new QuerybuilderTest().select('projects').fields('id').where('status = ?', 'active')
+    const q = new QuerybuilderTest().select('tasks').where('project_id IN ?', [sub]).getQueryAll()
+
+    expect(q.query).toEqual('SELECT * FROM tasks WHERE project_id IN (SELECT id FROM projects WHERE status = ?)')
+    expect(q.arguments).toEqual(['active'])
+  })
+
+  it('Subquery in a JOIN clause', () => {
+    const subquery = new QuerybuilderTest()
+      .select('orders')
+      .fields(['customer_id', 'COUNT(id) as order_count'])
+      .groupBy('customer_id')
+
+    const query = new QuerybuilderTest()
+      .select('customers')
+      .fields(['customers.name', 'oc.order_count'])
+      .join({
+        table: subquery,
+        alias: 'oc',
+        on: 'customers.id = oc.customer_id',
+      })
+      .getQueryAll()
+
+    expect(query.query).toEqual(
+      'SELECT customers.name, oc.order_count FROM customers' +
+        ' JOIN (SELECT customer_id, COUNT(id) as order_count FROM orders GROUP BY customer_id) AS oc' +
+        ' ON customers.id = oc.customer_id'
+    )
+    expect(query.arguments).toEqual([])
+  })
+
+  it('Subquery in a JOIN clause with params', () => {
+    const subquery = new QuerybuilderTest()
+      .select('orders')
+      .fields(['customer_id', 'COUNT(id) as order_count'])
+      .where('status = ?', 'completed')
+      .groupBy('customer_id')
+
+    const query = new QuerybuilderTest()
+      .select('customers')
+      .fields(['customers.name', 'oc.order_count'])
+      .join({
+        table: subquery,
+        alias: 'oc',
+        on: 'customers.id = oc.customer_id',
+      })
+      .getQueryAll()
+
+    expect(query.query).toEqual(
+      'SELECT customers.name, oc.order_count FROM customers' +
+        ' JOIN (SELECT customer_id, COUNT(id) as order_count FROM orders WHERE status = ? GROUP BY customer_id) AS oc' +
+        ' ON customers.id = oc.customer_id'
+    )
+    expect(query.arguments).toEqual(['completed'])
+  })
+})

--- a/tests/unit/subquery.test.ts
+++ b/tests/unit/subquery.test.ts
@@ -4,7 +4,7 @@ import { QuerybuilderTest } from '../utils'
 describe('Subqueries using SelectBuilder instance', () => {
   it('column IN (subquery) - passing SelectBuilder directly', () => {
     const sub = new QuerybuilderTest().select('allowed_ids').fields('id')
-    const q = new QuerybuilderTest().select('users').where('id IN ?', [sub]).getQueryAll()
+    const q = new QuerybuilderTest().select('users').where('id IN ?', sub).getQueryAll()
 
     expect(q.query).toEqual('SELECT * FROM users WHERE id IN (SELECT id FROM allowed_ids)')
     expect(q.arguments).toEqual([])
@@ -12,7 +12,7 @@ describe('Subqueries using SelectBuilder instance', () => {
 
   it('column IN (subquery) - subquery with parameters', () => {
     const sub = new QuerybuilderTest().select('projects').fields('id').where('status = ?', 'active')
-    const q = new QuerybuilderTest().select('tasks').where('project_id IN ?', [sub]).getQueryAll()
+    const q = new QuerybuilderTest().select('tasks').where('project_id IN ?', sub).getQueryAll()
 
     expect(q.query).toEqual('SELECT * FROM tasks WHERE project_id IN (SELECT id FROM projects WHERE status = ?)')
     expect(q.arguments).toEqual(['active'])

--- a/tests/unit/subquery.test.ts
+++ b/tests/unit/subquery.test.ts
@@ -18,6 +18,50 @@ describe('Subqueries using SelectBuilder instance', () => {
     expect(q.arguments).toEqual(['active'])
   })
 
+  it('column IN (subquery) - using an inline function', () => {
+    const q = new QuerybuilderTest()
+      .select('tasks')
+      .where('project_id IN ?', (qb) => qb.select('projects').fields('id').where('status = ?', 'active'))
+      .getQueryAll()
+
+    expect(q.query).toEqual('SELECT * FROM tasks WHERE project_id IN (SELECT id FROM projects WHERE status = ?)')
+    expect(q.arguments).toEqual(['active'])
+  })
+
+  it('EXISTS (subquery)', () => {
+    const sub = new QuerybuilderTest().select('permissions').where('user_id = ?', 100).where('action = ?', 'edit')
+    const q = new QuerybuilderTest().select('documents').where('EXISTS ?', sub).getQueryAll()
+
+    expect(q.query).toEqual('SELECT * FROM documents WHERE EXISTS (SELECT * FROM permissions WHERE user_id = ? AND action = ?)')
+    expect(q.arguments).toEqual([100, 'edit'])
+  })
+
+  it('Scalar subquery', () => {
+    const sub = new QuerybuilderTest().select('settings').fields('value').where('key = ?', 'default_role').limit(1)
+    const q = new QuerybuilderTest().select('users').where('role_id = ?', sub).getQueryAll()
+
+    expect(q.query).toEqual('SELECT * FROM users WHERE role_id = (SELECT value FROM settings WHERE key = ? LIMIT 1)')
+    expect(q.arguments).toEqual(['default_role'])
+  })
+
+  it('Subquery in a HAVING clause', () => {
+    const sub = new QuerybuilderTest()
+      .select('orders')
+      .fields('customer_id')
+      .groupBy('customer_id')
+      .having('SUM(total) > ?', 1000)
+    const q = new QuerybuilderTest()
+      .select('customers')
+      .fields(['id', 'name'])
+      .having('id IN ?', sub)
+      .getQueryAll()
+
+    expect(q.query).toEqual(
+      'SELECT id, name FROM customers HAVING id IN (SELECT customer_id FROM orders GROUP BY customer_id HAVING SUM(total) > ?)'
+    )
+    expect(q.arguments).toEqual([1000])
+  })
+
   it('Subquery in a JOIN clause', () => {
     const subquery = new QuerybuilderTest()
       .select('orders')


### PR DESCRIPTION
This commit introduces support for using subqueries as parameters within the `.where()` and `.having()` methods of the modular query builder.

Key changes include:

- Updated `SelectBuilder.where()` to recognize `SelectAll` objects (subquery configurations) as parameters. These are replaced with unique tokens in the condition string, and their definitions are stored.
- Enhanced the base `QueryBuilder` (`src/builder.ts`) to process these tokens during SQL generation. It recursively calls the main SQL compiler (`_select`) for each subquery, embedding its SQL and collecting its arguments in the correct order. This change applies to all database adapters extending `QueryBuilder` (PG, D1, DO).
- Modified `src/interfaces.ts`:
    - `Primitive` type now includes `SelectAll`.
    - `SelectOne` (and `SelectAll`) now have optional `subQueryPlaceholders` and `subQueryTokenNextId` fields to manage subquery state.
- Added a comprehensive suite of unit tests in `tests/unit/select.test.ts` to validate various subquery scenarios, including:
    - `IN (subquery)`
    - `EXISTS (subquery)`
    - `= (scalar subquery)`
    - Subqueries with and without parameters.
    - Combinations with main query parameters.
    - Multiple subqueries.
    - Subqueries in `HAVING` clauses.

This allows for more complex and powerful queries to be constructed in a type-safe and organized manner.