### PR TITLE
chore: remove un-needed await in docs

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -92,7 +92,7 @@ export class MyDurableObject extends DurableObject {
     void this.ctx.blockConcurrencyWhile(async () => {
       // Assuming 'migrations' is an array of Migration objects defined elsewhere
       const migrationBuilder = this.#qb.migrations({ migrations });
-      await migrationBuilder.apply(); // Ensure apply is awaited
+      migrationBuilder.apply();
     });
   }
 


### PR DESCRIPTION
We don't need to await the migrations apply on a durable object since a DOs sql execs happen in sync