### PR TITLE
Adds custom wrappers for additional logic before executing the query

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,7 @@ export type QueryLoggerMeta = {
 
 export type QueryBuilderOptions<IsAsync extends boolean = true> = {
   logger?: (query: RawQuery, meta: QueryLoggerMeta) => MaybeAsync<IsAsync, void>
+  wrapper?: Array<(callback: CallableFunction) => CallableFunction> | ((callback: CallableFunction) => CallableFunction)
 }
 
 export type DefaultObject = Record<string, Primitive>
@@ -18,10 +19,10 @@ export type DefaultReturnObject = Record<string, null | string | number | boolea
 
 export type Where =
   | {
-      conditions: string | Array<string>
-      // TODO: enable named parameters with DefaultObject
-      params?: Primitive | Primitive[]
-    }
+    conditions: string | Array<string>
+    // TODO: enable named parameters with DefaultObject
+    params?: Primitive | Primitive[]
+  }
   | string
   | Array<string>
 

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -59,4 +59,26 @@ describe('Logger', () => {
     // @ts-ignore
     expect(loggerMock.mock.calls[0][1].duration >= 30).toBeTruthy()
   })
+
+  it('wrappers are called', async () => {
+    const loggerMock = vi.fn()
+    const wrapperMock = vi.fn()
+
+    await new QuerybuilderTest({
+      wrapper: wrapperMock,
+      logger: loggerMock,
+    })
+      .fetchAll({
+        tableName: 'testTable',
+        fields: ['id', 'name'],
+        where: {
+          conditions: 'field = ?1',
+          params: ['test'],
+        },
+      })
+      .execute()
+
+    expect(wrapperMock.mock.calls).toHaveLength(1)
+    expect(loggerMock.mock.calls).toHaveLength(1)
+  })
 })

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -4,16 +4,32 @@ import { D1Result } from '../src/interfaces'
 import { Query } from '../src/tools'
 
 export class QuerybuilderTest extends QueryBuilder<{}> {
+  wrappedFunctions(func: CallableFunction) {
+    const wrapper = this.options?.wrapper
+    if (!wrapper) {
+      return func
+    }
+
+    if (Array.isArray(wrapper)) {
+      return wrapper.reduce((acc, currentWrapper) => {
+        return currentWrapper(acc);
+      }, func);
+    }
+    return wrapper(func);
+  }
+
   async execute(query: Query): Promise<Query<any>> {
     return this.loggerWrapper(query, this.options.logger, async () => {
-      return {
-        // @ts-ignore
-        results: {
-          query: query.query,
-          arguments: query.arguments,
-          fetchType: query.fetchType,
-        },
-      }
+      return this.wrappedFunctions(() => {
+        return {
+          results: {
+            query: query.query,
+            arguments: query.arguments,
+            fetchType: query.fetchType,
+          },
+        }
+      })
+      
     })
   }
 


### PR DESCRIPTION
This PR adds a new `wrappers` field. This is intended to configure one or more global wrappers that run before each query.

A good example use case for this would be:
- sending query related metrics to prometheus/datadog;
- wrapping the query around a tracing span