### PR TITLE
Implement PostgreSQL migrations initialization and tracking in tests

### DIFF
--- a/.changeset/fix-pg-migrations.md
+++ b/.changeset/fix-pg-migrations.md
@@ -1,0 +1,5 @@
+---
+"workers-qb": patch
+---
+
+Fix PostgreSQL migrations to create the internal migrations table with PostgreSQL-compatible SQL and avoid unnecessary placeholder rewriting for queries without parameters.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/site
 src/**/*.js
 docs/.vitepress/cache
 .env
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ docs/site
 src/**/*.js
 docs/.vitepress/cache
 .env
-.DS_Store

--- a/src/databases/pg.ts
+++ b/src/databases/pg.ts
@@ -6,7 +6,7 @@ import { TableSchema } from '../schema'
 import { Query } from '../tools'
 
 class PGMigrationsBuilder extends asyncMigrationsBuilder<PGResult> {
-  override async initialize(): Promise<void> {
+  async initialize(): Promise<void> {
     await this._builder
       .createTable({
         tableName: this._tableName,
@@ -18,7 +18,7 @@ class PGMigrationsBuilder extends asyncMigrationsBuilder<PGResult> {
       .execute()
   }
 
-  override async apply(): Promise<Array<{ name: string; sql: string }>> {
+  async apply(): Promise<Array<{ name: string; sql: string }>> {
     const appliedMigrations: Array<{ name: string; sql: string }> = []
 
     for (const migration of await this.getUnapplied()) {
@@ -53,7 +53,6 @@ class PGMigrationsBuilder extends asyncMigrationsBuilder<PGResult> {
 
 export class PGQB<Schema extends TableSchema = {}> extends QueryBuilder<Schema, PGResult, true> {
   public db: any
-  _migrationsBuilder = PGMigrationsBuilder
 
   constructor(db: any, options?: QueryBuilderOptions) {
     super(options)
@@ -61,7 +60,7 @@ export class PGQB<Schema extends TableSchema = {}> extends QueryBuilder<Schema, 
   }
 
   migrations(options: MigrationOptions) {
-    return new this._migrationsBuilder(options, this)
+    return new PGMigrationsBuilder(options, this)
   }
 
   async connect() {

--- a/src/databases/pg.ts
+++ b/src/databases/pg.ts
@@ -5,9 +5,55 @@ import { asyncMigrationsBuilder, MigrationOptions } from '../migrations'
 import { TableSchema } from '../schema'
 import { Query } from '../tools'
 
+class PGMigrationsBuilder extends asyncMigrationsBuilder<PGResult> {
+  override async initialize(): Promise<void> {
+    await this._builder
+      .createTable({
+        tableName: this._tableName,
+        schema: `id         SERIAL PRIMARY KEY,
+               name       TEXT UNIQUE,
+               applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL`,
+        ifNotExists: true,
+      })
+      .execute()
+  }
+
+  override async apply(): Promise<Array<{ name: string; sql: string }>> {
+    const appliedMigrations: Array<{ name: string; sql: string }> = []
+
+    for (const migration of await this.getUnapplied()) {
+      await this._builder.raw({ query: 'BEGIN' }).execute()
+
+      try {
+        await this._builder
+          .raw({
+            query: migration.sql,
+          })
+          .execute()
+
+        await this._builder
+          .raw({
+            query: `INSERT INTO ${this._tableName} (name)
+            values (?);`,
+            args: [migration.name],
+          })
+          .execute()
+
+        await this._builder.raw({ query: 'COMMIT' }).execute()
+        appliedMigrations.push(migration)
+      } catch (error) {
+        await this._builder.raw({ query: 'ROLLBACK' }).execute()
+        throw error
+      }
+    }
+
+    return appliedMigrations
+  }
+}
+
 export class PGQB<Schema extends TableSchema = {}> extends QueryBuilder<Schema, PGResult, true> {
   public db: any
-  _migrationsBuilder = asyncMigrationsBuilder
+  _migrationsBuilder = PGMigrationsBuilder
 
   constructor(db: any, options?: QueryBuilderOptions) {
     super(options)
@@ -15,7 +61,7 @@ export class PGQB<Schema extends TableSchema = {}> extends QueryBuilder<Schema, 
   }
 
   migrations(options: MigrationOptions) {
-    return new asyncMigrationsBuilder<PGResult>(options, this)
+    return new this._migrationsBuilder(options, this)
   }
 
   async connect() {

--- a/tests/unit/pg.test.ts
+++ b/tests/unit/pg.test.ts
@@ -1,19 +1,29 @@
 import { describe, expect, it } from 'vitest'
-import { PGQB } from '../../src'
+import { Migration, PGQB } from '../../src'
 
 /**
  * A mock pg client that captures the last query sent to it.
  */
 function makeMockPgClient() {
   let lastQuery: { text: string; values?: any[] } | null = null
+  const queryHistory: Array<{ text: string; values?: any[] }> = []
 
   const client = {
     query(params: { text: string; values?: any[] }) {
       lastQuery = params
-      return Promise.resolve({ command: 'SELECT', oid: null, rowCount: 0, rows: [] })
+      queryHistory.push(params)
+
+      if (params.text.includes('SELECT * FROM migrations')) {
+        return Promise.resolve({ command: 'SELECT', oid: null, rowCount: 0, rows: [] })
+      }
+
+      return Promise.resolve({ command: 'OK', oid: null, rowCount: 0, rows: [] })
     },
     getLastQuery() {
       return lastQuery
+    },
+    getQueryHistory() {
+      return queryHistory
     },
   }
   return client
@@ -91,5 +101,65 @@ describe('PGQB parameter placeholder conversion', () => {
     const lastQuery = client.getLastQuery()
     expect(lastQuery?.text).toBe('SELECT * FROM users')
     expect(lastQuery?.values).toEqual([])
+  })
+
+  it('uses PostgreSQL-compatible schema when initializing migrations', async () => {
+    const client = makeMockPgClient()
+    const qb = new PGQB(client)
+
+    await qb.migrations({ migrations: [] }).initialize()
+
+    const lastQuery = client.getLastQuery()
+    expect(lastQuery?.text).toContain('SERIAL PRIMARY KEY')
+    expect(lastQuery?.text).not.toContain('AUTOINCREMENT')
+  })
+
+  it('applies migrations with PostgreSQL-compatible tracking queries', async () => {
+    const client = makeMockPgClient()
+    const qb = new PGQB(client)
+    const migrations: Migration[] = [
+      {
+        name: '0001_create_users_table.sql',
+        sql: 'CREATE TABLE users (id SERIAL PRIMARY KEY);',
+      },
+    ]
+
+    const applied = await qb.migrations({ migrations }).apply()
+
+    expect(applied).toEqual(migrations)
+
+    const queryHistory = client.getQueryHistory()
+    expect(queryHistory).toHaveLength(6)
+    expect(queryHistory[0]?.text).toContain('CREATE TABLE IF NOT EXISTS migrations')
+    expect(queryHistory[0]?.text).toContain('SERIAL PRIMARY KEY')
+    expect(queryHistory[1]?.text).toBe('SELECT * FROM migrations ORDER BY id')
+    expect(queryHistory[2]?.text).toBe('BEGIN')
+    expect(queryHistory[3]?.text).toContain('CREATE TABLE users (id SERIAL PRIMARY KEY);')
+    expect(queryHistory[3]?.values).toBeUndefined()
+    expect(queryHistory[4]?.text).toContain('INSERT INTO migrations (name)')
+    expect(queryHistory[4]?.text).toContain('values ($1);')
+    expect(queryHistory[4]?.values).toEqual(['0001_create_users_table.sql'])
+    expect(queryHistory[5]?.text).toBe('COMMIT')
+  })
+
+  it('does not send multi-command parameterized migration queries to PostgreSQL', async () => {
+    const client = makeMockPgClient()
+    const qb = new PGQB(client)
+    const migrations: Migration[] = [
+      {
+        name: '0001_create_users_table.sql',
+        sql: 'CREATE TABLE users (id SERIAL PRIMARY KEY); CREATE INDEX users_id_idx ON users (id);',
+      },
+    ]
+
+    await qb.migrations({ migrations }).apply()
+
+    const queryHistory = client.getQueryHistory()
+    expect(queryHistory[3]?.text).toBe(
+      'CREATE TABLE users (id SERIAL PRIMARY KEY); CREATE INDEX users_id_idx ON users (id);'
+    )
+    expect(queryHistory[3]?.values).toBeUndefined()
+    expect(queryHistory[4]?.text).toBe('INSERT INTO migrations (name) values ($1);')
+    expect(queryHistory[4]?.values).toEqual(['0001_create_users_table.sql'])
   })
 })


### PR DESCRIPTION
This pull request updates the PostgreSQL query builder and its migration system to ensure that migrations use PostgreSQL-compatible SQL syntax and tracking logic. It introduces a custom migrations builder for PostgreSQL and adds comprehensive tests to verify the correct behavior.

**PostgreSQL Migrations Improvements:**

* Added a new `PGMigrationsBuilder` class that overrides the migration table initialization to use PostgreSQL-specific schema (e.g., `SERIAL PRIMARY KEY` instead of `AUTOINCREMENT`) and ensures compatibility with PostgreSQL SQL syntax (`src/databases/pg.ts`).
* Updated the `PGQB` class to use the new `PGMigrationsBuilder` for handling migrations, ensuring all migration operations are PostgreSQL-compatible (`src/databases/pg.ts`).

**Testing Enhancements:**

* Improved the mock PostgreSQL client in tests to track query history, allowing for more thorough assertions about the sequence and content of migration queries (`tests/unit/pg.test.ts`).
* Added tests to verify that migration initialization and application use PostgreSQL-compatible schema and tracking queries, confirming correct table creation and migration tracking (`tests/unit/pg.test.ts`).